### PR TITLE
Handle post and dev releases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Fix new versions if they had dev/post release suffix.
+  [gforcada]
 
 1.5.1 (2016-04-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Bug fixes:
 - Fix new versions if they had dev/post release suffix.
   [gforcada]
 
+
 1.5.1 (2016-04-28)
 ------------------
 

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -78,7 +78,7 @@ class VersionsFile(object):
             versionstxt += newline
 
         reg = re.compile(
-            "(^{0}[\s\=]+)[0-9\.abrc]+".format(package_name),
+            "(^{0}[\s\=]+)[0-9\.abrc]+(.post\d+)?(.dev\d+)?".format(package_name),
             re.MULTILINE
         )
         newVersionsTxt = reg.sub(r"\g<1>{0}".format(new_version), versionstxt)


### PR DESCRIPTION
If a release like '1.0dev0' was made,
when making release 1.1 the versions.cfg line would end like '1.1dev0' instead of '1.1'.