### PR TITLE
Split updating/pushing coredev

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Ask before pushing to coredev, after updating the checkouts and versions.  [maurits]
 
 Bug fixes:
 

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -186,8 +186,9 @@ def update_core(data):
         g.add('checkouts.cfg')
         print "Committing changes."
         g.commit(message=message)
-        print "Pushing changes to server."
-        g.push()
+        if ask("Ok to push coredev?", default=True):
+            print "Pushing changes to server."
+            g.push()
 
 
 def update_versions(package_name, new_version):


### PR DESCRIPTION
@plone/release-team When releasing a package that has already been correctly added to checkouts.cfg and Jenkins passes, a new release for this package is highly unlikely to cause a failure. It is still good to test them of course. But when I release a bunch of packages, I like to do say three or four quickly after each other. I would rather push the changes to checkouts.cfg and versions.cfg for all at the same time, instead of swamping Jenkins with multiple uninteresting jobs. This change makes that doable.
Do you agree?
Of course: don't do dozens of packages this way... Four is probably a good soft maximum.