### PR TITLE
Update pypi.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- change  pypi-url from http to https
+- Change  pypi-url from http to https.
+  [fgrcon]
 
 
 1.5.2 (2016-06-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- change  pypi-url from http to https
 
 
 1.5.2 (2016-06-12)

--- a/plone/releaser/pypi.py
+++ b/plone/releaser/pypi.py
@@ -3,7 +3,7 @@ import xmlrpclib
 
 
 def get_users_with_release_rights(package_name):
-    client = xmlrpclib.ServerProxy('http://pypi.python.org/pypi')
+    client = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
     existing_admins = set([
         user for role, user in client.package_roles(package_name)])
     return existing_admins


### PR DESCRIPTION
fixes:
````
Enter version [3.1]: 
Traceback (most recent call last):
  File "../../bin/fullrelease", line 40, in <module>
    sys.exit(zest.releaser.fullrelease.main())
  File "/usr/local/_eggs/zest.releaser-6.6.4-py2.7.egg/zest/releaser/fullrelease.py", line 23, in main
    prereleaser.run()
  File "/usr/local/_eggs/zest.releaser-6.6.4-py2.7.egg/zest/releaser/baserelease.py", line 307, in run
    self._run_hooks('middle')
  File "/usr/local/_eggs/zest.releaser-6.6.4-py2.7.egg/zest/releaser/baserelease.py", line 302, in _run_hooks
    utils.run_hooks(self.setup_cfg, which_releaser, when, self.data)
  File "/usr/local/_eggs/zest.releaser-6.6.4-py2.7.egg/zest/releaser/utils.py", line 579, in run_hooks
    run_entry_points(which_releaser, when, data)
  File "/usr/local/_eggs/zest.releaser-6.6.4-py2.7.egg/zest/releaser/utils.py", line 595, in run_entry_points
    plugin(data)
  File "/usr/local/_eggs/plone.releaser-1.5.2-py2.7.egg/plone/releaser/release.py", line 168, in check_pypi_access
    if not can_user_release_package_to_pypi(pypi_user, data['name']):
  File "/usr/local/_eggs/plone.releaser-1.5.2-py2.7.egg/plone/releaser/pypi.py", line 13, in can_user_release_package_to_pypi
    return user in get_users_with_release_rights(package_name)
  File "/usr/local/_eggs/plone.releaser-1.5.2-py2.7.egg/plone/releaser/pypi.py", line 8, in get_users_with_release_rights
    user for role, user in client.package_roles(package_name)])
  File "/usr/lib/python2.7/xmlrpclib.py", line 1233, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1591, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.7/xmlrpclib.py", line 1273, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1321, in single_request
    response.msg,
xmlrpclib.ProtocolError: <ProtocolError for pypi.python.org/pypi: 403 Must access using HTTPS instead of HTTP>


````