### PR TITLE
Update other Plone core branches when releasing packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,10 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- New zest.releaser hook: update other buildout.coredev branches as well.
+  This automates the manual bookeeping that one has to do whenever releasing packages:
+  i.e. to check if the package just released is also checked out and used in other buildout.coredev branches.
+  [gforcada]
 
 Bug fixes:
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup(
         ],
         'zest.releaser.releaser.after': [
             'update_core=plone.releaser.release:update_core',
+            ('update_other_core_branches='
+             'plone.releaser.release:update_other_core_branches'),
         ],
         'zest.releaser.postreleaser.before': [
             'set_new_changelog=plone.releaser.release:set_new_changelog',


### PR DESCRIPTION
@esteele @mauritsvanrees there you go, I tested it with a few packages until I finally fixed all the errors, see plone.synchronize as the last release made across all buildout.coredev branches.