### PR TITLE
Add pyproject.toml with settings for towncrier. [Don't merge]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-CHANGES.rst merge=union

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-.. NOTE: You should *NOT* be adding new change log entries to this file, this
-         file is managed by towncrier. You *may* edit previous change logs to
-         fix problems like typo corrections or such.
+.. You should *NOT* be adding new change log entries to this file, this
+   file is managed by towncrier. You *may* edit previous change logs to
+   fix problems like typo corrections or such.
 
-         To add a new change log entry, please see
-             https://pip.pypa.io/en/latest/development/#adding-a-news-entry
+   To add a new change log entry, please see
+   https://pip.pypa.io/en/latest/development/#adding-a-news-entry
+   TODO: use a Plone specific link.
 
 .. towncrier release notes start
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,20 +1,14 @@
 Changelog
 =========
 
-1.6.1 (unreleased)
-------------------
+.. NOTE: You should *NOT* be adding new change log entries to this file, this
+         file is managed by towncrier. You *may* edit previous change logs to
+         fix problems like typo corrections or such.
 
-Breaking changes:
+         To add a new change log entry, please see
+             https://pip.pypa.io/en/latest/development/#adding-a-news-entry
 
-- *add item here*
-
-New features:
-
-- *add item here*
-
-Bug fixes:
-
-- *add item here*
+.. towncrier release notes start
 
 
 1.6.0 (2018-04-04)

--- a/news/1.unknown
+++ b/news/1.unknown
@@ -1,0 +1,1 @@
+This is ignored, because the .unknown suffix is unknown in pyproject.toml.

--- a/news/17.feature
+++ b/news/17.feature
@@ -1,0 +1,1 @@
+Start using towncrier for our own ``CHANGES.rst``.  [maurits]

--- a/news/234.misc
+++ b/news/234.misc
@@ -1,0 +1,11 @@
+The .misc suffix not configured in pyproject.toml so it is not shown.
+
+We could define this in pyproject.toml:
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Miscellaneous:"
+# This type is not shown.
+showcontent = false
+
+But then towncrier still creates a Miscellaneous sub header without the content of this file, but *with* the issue number...

--- a/news/42.breaking
+++ b/news/42.breaking
@@ -1,0 +1,1 @@
+We broke everything. Sorry.

--- a/news/444.bugfix
+++ b/news/444.bugfix
@@ -1,0 +1,6 @@
+Try a multiline entry.
+I would almost add an empty line here, as you would do with git,
+but that is not needed.
+I can still link to an `issue in CMFPlone <https://github.com/plone/Products.CMFPlone/issues/random>`_.
+And I can add an author.
+[maurits]

--- a/news/456.bugfix
+++ b/news/456.bugfix
@@ -1,0 +1,1 @@
+Sample change

--- a/news/555.bugfix
+++ b/news/555.bugfix
@@ -1,0 +1,7 @@
+Try an entry with **markup**.
+And especially::
+
+    Some inline code
+
+Okay, that does not work: everything gets put on one line.
+See https://github.com/hawkowl/towncrier/issues/80

--- a/news/no-integer.bugfix
+++ b/news/no-integer.bugfix
@@ -1,0 +1,1 @@
+Test a non-integer as issue number.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.towncrier]
+# package is required, and sadly must be importable, even though we don't want to use it.
+# It is used to get the version, but we will pass the version on the command line with --version.
+# The default title_format uses it, but we have our own version which doesn't.
+# Fortunately, after release of https://github.com/hawkowl/towncrier/pull/107
+# we should be able to pass it on the command line with --name.
+package = "plone.releaser"
+# Default issue_format is more or less: #{issue}.
+# We can make a link to the issue tracker of the project,
+# but tricky is that this may need to be the issue tracker of Products.CMFPlone.
+# You can still link to that manually in the news fragment.
+issue_format = "`Issue #{issue} <https://github.com/plone/plone.releaser/issues/{issue}>`_"
+filename = "CHANGES.rst"
+directory = "news/"
+title_format = "{version} ({project_date})"
+# First underline is used for version/date header.
+# Second underline is used for the type names (like 'Bug fixes:').
+underlines = ["-", ""]
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking changes:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "New features:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bug fixes:"
+showcontent = true


### PR DESCRIPTION
And add sample news fragments in the news directory. **So do not merge!**

Usage for now:
- create a virtualenv, `pip install towncrier`, go back to the plone.releaser directory
- To see what would happen: `towncrier --version=1.6.1 --draft`
- Or to really change the CHANGES.rst file: `towncrier --version=1.6.1`

The configuration must be in a `pyproject.toml` file. I have included some comments inline in this file. The one in this PR works for `plone.releaser`. For most Plone packages we would need to pass `--name project.name` instead of setting a `package` in the config, which requires a release of https://github.com/hawkowl/towncrier/pull/107. Even better would be if `package` can be completely optional, for which I have opened issue  https://github.com/hawkowl/towncrier/issues/111.

Sample output:

```
$ ~/envs/towncrier/bin/towncrier --version=1.6.1 --draft
Loading template...
Finding news fragments...
Rendering news fragments...
Draft only -- nothing has been written.
What is seen below is what would be written.

1.6.1 (2018-04-10)
------------------


Breaking changes:


- We broke everything. Sorry. (`Issue #42
  <https://github.com/plone/plone.releaser/issues/42>`_)


New features:


- Start using towncrier for our own ``CHANGES.rst``. [maurits] (`Issue #17
  <https://github.com/plone/plone.releaser/issues/17>`_)


Bug fixes:


- Test a non-integer as issue number. (`Issue #no-integer
  <https://github.com/plone/plone.releaser/issues/no-integer>`_)
- Try a multiline entry. I would almost add an empty line here, as you would do
  with git, but that is not needed. I can still link to an `issue in CMFPlone
  <https://github.com/plone/Products.CMFPlone/issues/random>`_. And I can add
  an author. [maurits] (`Issue #444
  <https://github.com/plone/plone.releaser/issues/444>`_)
- Sample change (`Issue #456
  <https://github.com/plone/plone.releaser/issues/456>`_)
- Try an entry with **markup**. And especially:: Some inline code Okay, that
  does not work: everything gets put on one line. See
  https://github.com/hawkowl/towncrier/issues/80 (`Issue #555
  <https://github.com/plone/plone.releaser/issues/555>`_)
```
