### PR TITLE
Fix for Python 3 compatibility

### DIFF
--- a/plone/releaser/pypi.py
+++ b/plone/releaser/pypi.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
-import xmlrpclib
+
+try:
+    from xmlrpclib import ServerProxy
+except ImportError:
+    from xmlrpc.client import ServerProxy
 
 
 def get_users_with_release_rights(package_name):
-    client = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
+    client = ServerProxy('https://pypi.python.org/pypi')
     existing_admins = set([
         user for role, user in client.package_roles(package_name)])
     return existing_admins


### PR DESCRIPTION
Work around for xmlrpclib/xmlrpc differences.