### PR TITLE
Fix pypi URL for xmlrpc queries

### DIFF
--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,0 +1,2 @@
+Fix pypi URL.
+[gforcada]

--- a/plone/releaser/pypi.py
+++ b/plone/releaser/pypi.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 def get_users_with_release_rights(package_name):
-    client = ServerProxy('https://pypi.python.org/pypi')
+    client = ServerProxy('https://pypi.org/pypi')
     existing_admins = set([
         user for role, user in client.package_roles(package_name)])
     return existing_admins


### PR DESCRIPTION
That's the URL used on warehouse documentation: https://warehouse.pypa.io/api-reference/xml-rpc/