### PR TITLE
Handle coredev branch 6.0 when releasing packages.

### DIFF
--- a/news/27.feature
+++ b/news/27.feature
@@ -1,0 +1,2 @@
+Handle coredev branch 6.0 when releasing packages.
+[maurits]

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -207,7 +207,7 @@ def update_core(data, branch=None):
 
 
 def update_other_core_branches(data):
-    CORE_BRANCHES = ["4.3", "5.1", "5.2"]
+    CORE_BRANCHES = ["4.3", "5.1", "5.2", "6.0"]
     package_name = data["name"]
     root_path = os.path.join(os.getcwd(), "../../")
 


### PR DESCRIPTION
Fixes https://github.com/plone/plone.releaser/issues/27

No Jenkins tests needed, I would say.