### PR TITLE
Fixed adding some package versions twice when releasing.

### DIFF
--- a/news/24.bugfix
+++ b/news/24.bugfix
@@ -1,0 +1,2 @@
+Fixed adding some package versions twice when releasing.
+[maurits]


### PR DESCRIPTION
When releasing a package with a version pin in `[versions:python27]`
this pin would correctly get updated, but an extra pin added at the bottom.

Fixes https://github.com/plone/plone.releaser/issues/24

Tested with Python 2 and 3.

No Jenkins needed, I think.