### PR TITLE
Ask before pushing an updated version when running 'report'.

### DIFF
--- a/news/32.bugfix
+++ b/news/32.bugfix
@@ -1,0 +1,1 @@
+Ask before pushing an updated version when running 'report'.  [maurits]

--- a/plone/releaser/package.py
+++ b/plone/releaser/package.py
@@ -277,4 +277,6 @@ class Package(object):
                 versions_path = os.path.join(os.getcwd(), "versions.cfg")
                 core_repo.git.add(versions_path)
                 core_repo.git.commit(message="{0}={1}".format(self.name, tag))
-                core_repo.git.push()
+                if confirm("Ok to push coredev?", default=True, skip=not self.interactive):
+                    print("Pushing changes to server.")
+                    core_repo.git.push()


### PR DESCRIPTION
Fixes https://github.com/plone/plone.releaser/issues/32

I am using this now in 5.2:

```
Newer version 2.4.4 is available for Products.CMFCore (Currently 2.4.2)
Update versions.cfg? (Y/n)
Ok to push coredev?? (Y/n)n
```

Works: the change remains local now.