### PR TITLE
Fixed detecting changes in packages that are missing from checkouts.

### DIFF
--- a/news/35.bugfix
+++ b/news/35.bugfix
@@ -1,0 +1,2 @@
+Fixed detecting changes in packages that are missing from checkouts.
+[maurits]


### PR DESCRIPTION
I ran `bin/manage report --interactive` with this just now on coredev 5.2 and it went well. It detected about seven missing checkouts, so not as bad as I feared.