### PR TITLE
Support env var to not offer pushing to buildout.coredev

### DIFF
--- a/news/37.feature
+++ b/news/37.feature
@@ -1,0 +1,4 @@
+Support env var PLONE_RELEASER_MULTI_PACKAGES to signal doing multiple releases.
+We still change `checkouts.cfg` and `versions.cfg` in the relevant coredev branches then,
+but we do not offer to push them.
+[maurits]

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -198,6 +198,21 @@ def update_core(data, branch=None):
         g.add("checkouts.cfg")
         print("Committing changes.")
         g.commit(message=message)
+        # When doing releases of several packages in a row,
+        # it is better to not push, because this means a needlessly high load on Jenkins.
+        # Also, if you create a release and immediately push,
+        # then Jenkins will not find the new release yet and fail:
+        # it takes a few minutes for the release to be propagated to all PyPI mirrors.
+        # Pushing still seems the best default, but let's have an easy way to not push.
+        print("Checking PLONE_RELEASER_MULTI_PACKAGES env variable.")
+        try:
+            multi = int(os.getenv("PLONE_RELEASER_MULTI_PACKAGES"))
+        except (TypeError, ValueError, AttributeError):
+            print("ERROR: could not parse PLONE_RELEASER_MULTI_PACKAGES env var. Ignoring it.")
+            multi = False
+        if multi:
+            print("PLONE_RELEASER_MULTI_PACKAGES env variable set, so not pushing to coredev.")
+            return
         msg = "Ok to push coredev?"
         if branch:
             msg = "Ok to push coredev {0}?".format(branch)


### PR DESCRIPTION
When doing releases of several packages in a row, it is better to not push, because this means a needlessly high load on Jenkins.
Also, if you create a release and immediately push, then Jenkins will not find the new release yet and fail:
it takes a few minutes for the release to be propagated to all PyPI mirrors.
Pushing still seems the best default, but let's have an easy way to not push.
We look for environment variable `PLONE_RELEASER_MULTI_PACKAGES`.
Best is value 0 or 1, but we try not to break if you have something else.

I have been using this (well, a hardcoded variant in a local change) for a few months now while making multiple releases.