### PR TITLE
When filtering interesting commits, catch git errors

### DIFF
--- a/news/39.bugfix
+++ b/news/39.bugfix
@@ -1,0 +1,3 @@
+When reporting interesting commits, catch errors when comparing with previously ignored commit.
+Fixes `issue 39 <https://github.com/plone/plone.releaser/issues/39>`_.
+[maurits]

--- a/plone/releaser/package.py
+++ b/plone/releaser/package.py
@@ -220,7 +220,9 @@ class Package(object):
         try:
             commits = self._commits_between(repo, self.version, self.source.branch)
         except git.exc.GitCommandError:
-            print("\nCould not read commits for package {0}".format(self.name))
+            print("\nCould not read commits between {0} and {1} for package {2}".format(
+                self.version, self.source.branch, self.name
+                ))
 
         return commits
 

--- a/plone/releaser/package.py
+++ b/plone/releaser/package.py
@@ -137,8 +137,11 @@ class Package(object):
                         repo, latest_ignored_commit, self.source.branch
                     )
                 except git.exc.GitCommandError:
-                    print("\nCould not read commits for package {0}".format(self.name))
-                    return
+                    # Most likely error is that this fails:
+                    # git rev-list latest_ignored_commit..master
+                    # This happens when latest_ignored_commit is not on the master branch.
+                    # See https://github.com/plone/plone.releaser/issues/39
+                    commits_since_ignore = interesting_commits
                 if not commits_since_ignore:
                     # Okay, nothing interesting.
                     self.remove()


### PR DESCRIPTION
When reporting interesting commits, catch errors when comparing with previously ignored commit.

Fixes https://github.com/plone/plone.releaser/issues/39.