### PR TITLE
report: add sleep and start parameters.

### DIFF
--- a/plone/releaser/package.py
+++ b/plone/releaser/package.py
@@ -116,15 +116,18 @@ class Package(object):
                 # so we are done.
                 self.remove()
                 return
-            # The latest commit is number zero.
-            latest_commit_message = commits_since_release[0].message
-            if (
-                "Back to development" in latest_commit_message
-                or latest_commit_message.startswith("vb")
-            ):
-                # Only the regular version bump, so we are done.
-                self.remove()
-                return
+            if len(commits_since_release) == 1:
+                # If there is only one commit since release and it is only the
+                # regular version bump, then we are done.
+                latest_commit_message = commits_since_release[0].message.lower()
+                if (
+                    latest_commit_message.startswith("vb")
+                    or "back to development" in latest_commit_message
+                    or "bump version" in latest_commit_message
+                    or "version bump" in latest_commit_message
+                ):
+                    self.remove()
+                    return
 
             # Maybe there are more commits but we have previously seen them
             # and decided they are not interesting.  We only want to show


### PR DESCRIPTION
GitHub can time out when we do so many clones. Sample error that I want to prevent:

```
$ bin/manage report --interactive
Scanning |#                               | 7/141
Traceback (most recent call last):
  File "/Users/maurits/community/plone-coredev/6.0/bin/manage", line 72, in <module>
    sys.exit(plone.releaser.manage.manage())
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.releaser/plone/releaser/manage.py", line 181, in __call__
    parser.dispatch()
  File "/Users/maurits/shared-eggs/cp310/argh-0.26.2-py3.10.egg/argh/helpers.py", line 55, in dispatch
    return dispatch(self, *args, **kwargs)
  File "/Users/maurits/shared-eggs/cp310/argh-0.26.2-py3.10.egg/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/Users/maurits/shared-eggs/cp310/argh-0.26.2-py3.10.egg/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/Users/maurits/shared-eggs/cp310/argh-0.26.2-py3.10.egg/argh/dispatching.py", line 260, in _call
    result = function(*positional, **keywords)
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.releaser/plone/releaser/manage.py", line 86, in checkAllPackagesForUpdates
    pkg(action=ACTION_INTERACTIVE)
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.releaser/plone/releaser/package.py", line 103, in __call__
    with git_repo(self.source) as repo:
  File "/Users/maurits/.pyenv/versions/3.10.4/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.releaser/plone/releaser/package.py", line 32, in git_repo
    repo = git.Repo.clone_from(source.url, tmp_dir, branch=source.branch, depth=100)
  File "/Users/maurits/shared-eggs/cp310/GitPython-3.1.27-py3.10.egg/git/repo/base.py", line 1148, in clone_from
    return cls._clone(git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs)
  File "/Users/maurits/shared-eggs/cp310/GitPython-3.1.27-py3.10.egg/git/repo/base.py", line 1086, in _clone
    finalize_process(proc, stderr=stderr)
  File "/Users/maurits/shared-eggs/cp310/GitPython-3.1.27-py3.10.egg/git/util.py", line 386, in finalize_process
    proc.wait(**kwargs)
  File "/Users/maurits/shared-eggs/cp310/GitPython-3.1.27-py3.10.egg/git/cmd.py", line 502, in wait
    raise GitCommandError(remove_password_if_present(self.args), status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v --branch=master --depth=100 https://github.com/zopefoundation/Products.CMFUid.git /var/folders/26/1plvhxbs6yx7g_82v2xdxc500000gn/T/tmp79ak9ixo
  stderr: 'Cloning into '/var/folders/26/1plvhxbs6yx7g_82v2xdxc500000gn/T/tmp79ak9ixo'...
fatal: unable to access 'https://github.com/zopefoundation/Products.CMFUid.git/': Failed to connect to github.com port 443: Operation timed out
```

I am trying this out now on coredev 6.0.
