### PR TITLE
Fix ValueError when calling 'bin/manage launchpad 5.2.10.1'

### DIFF
--- a/news/45.bugfix
+++ b/news/45.bugfix
@@ -1,0 +1,2 @@
+Fix ValueError when calling ``bin/manage launchpad 5.2.10.1``.
+[maurits]

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -123,7 +123,14 @@ def changelog(**kwargs):
 def create_launchpad_release(version):
     launchpad = Launchpad.login_with("plone.releaser", "production")
     plone = launchpad.projects["plone"]
-    parsed_version = StrictVersion(version)
+    try:
+        parsed_version = StrictVersion(version)
+    except ValueError:
+        # ValueError: invalid version number '5.2.10.1'
+        if version.count(".") < 3:
+            raise
+        adapted_version = ".".join(version.split(".")[:3])
+        parsed_version = StrictVersion(adapted_version)
     # Blech. This feels flimsy
     series_name = ".".join([str(a) for a in parsed_version.version[0:2]])
     series = plone.getSeries(name=series_name)


### PR DESCRIPTION
```
$ bin/manage launchpad 5.2.10.1
Traceback (most recent call last):
  File "bin/manage", line 71, in <module>
    sys.exit(plone.releaser.manage.manage())
  File "/Users/maurits/shared-eggs/cp27m/plone.releaser-1.8.7-py2.7.egg/plone/releaser/manage.py", line 181, in __call__
    parser.dispatch()
  File "/Users/maurits/shared-eggs/cp27m/argh-0.26.2-py2.7.egg/argh/helpers.py", line 55, in dispatch
    return dispatch(self, *args, **kwargs)
  File "/Users/maurits/shared-eggs/cp27m/argh-0.26.2-py2.7.egg/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/Users/maurits/shared-eggs/cp27m/argh-0.26.2-py2.7.egg/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/Users/maurits/shared-eggs/cp27m/argh-0.26.2-py2.7.egg/argh/dispatching.py", line 260, in _call
    result = function(*positional, **keywords)
  File "/Users/maurits/shared-eggs/cp27m/plone.releaser-1.8.7-py2.7.egg/plone/releaser/manage.py", line 126, in create_launchpad_release
    parsed_version = StrictVersion(version)
  File "/Users/maurits/.pyenv/versions/2.7.18/lib/python2.7/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/Users/maurits/.pyenv/versions/2.7.18/lib/python2.7/distutils/version.py", line 107, in parse
    raise ValueError, "invalid version number '%s'" % vstring
ValueError: invalid version number '5.2.10.1'
```