### PR TITLE
Allow disabling PyPI rights check

### DIFF
--- a/news/50.bugfix
+++ b/news/50.bugfix
@@ -1,0 +1,4 @@
+Allow disabling PyPI rights check, as this does not know how to check organisations.
+Set env variable ``PLONE_RELEASER_CHECK_PYPI_ACCESS=0`` if you want to disable it.
+Also, we do not check PyPI if the user is `__token__`, so using an API token.
+[maurits]

--- a/plone/releaser/pypi.py
+++ b/plone/releaser/pypi.py
@@ -2,10 +2,15 @@ from xmlrpc.client import ServerProxy
 
 
 def get_users_with_release_rights(package_name):
+    # Note: this is deprecated, but I don't see an alternative:
+    # https://warehouse.pypa.io/api-reference/xml-rpc.html
     client = ServerProxy("https://pypi.org/pypi")
     existing_admins = {user for role, user in client.package_roles(package_name)}
     return existing_admins
 
 
 def can_user_release_package_to_pypi(user, package_name):
+    # Note: most packages that we release, will have/get the 'plone' organisation
+    # as owner, and the code here does not know this, and does not know if you
+    # are a member of this PyPI organisation.
     return user in get_users_with_release_rights(package_name)


### PR DESCRIPTION
This does not know how to check organisations.  Fixes issue #50.

Set env variable ``PLONE_RELEASER_CHECK_PYPI_ACCESS=0`` if you want to disable it. Also, we do not check PyPI if the user is `__token__`, so using an API token.

Unrelated: add 6.1 to core branches to update.

I did not have the chance to try it out yet.