### PR TITLE
Set constraints and checkouts in pip/mxdev files as well

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,0 +1,18 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+name: Meta
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: plone/meta/.github/workflows/test.yml@master

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,7 @@ include *.py
 include *.rst
 include buildout.cfg
 include pyproject.toml
+graft plone
 recursive-exclude news *
 exclude news
+global-exclude *.pyc

--- a/news/52.bugfix
+++ b/news/52.bugfix
@@ -1,0 +1,2 @@
+Check all ``versions*.cfg`` files when updating a pin.
+[maurits]

--- a/news/53.feature.1
+++ b/news/53.feature.1
@@ -1,0 +1,2 @@
+Enable updating versions in pip constraints files.
+[maurits]

--- a/news/53.feature.2
+++ b/news/53.feature.2
@@ -1,0 +1,2 @@
+Enable updating checkouts in mxdex.ini files.
+[maurits]

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -184,10 +184,16 @@ class CheckoutsFile(UserDict):
             # Include this line only if we want it enabled.
             if enabled:
                 lines.append(line)
-        # The only case we still need to handle, is when the package was not found
-        # and enabled=True.
-        if enabled and not found:
-            lines.append(f"    {package_name}")
+                print(f"{self.file_location}: {package_name} already in checkouts.")
+            else:
+                print(f"{self.file_location}: {package_name} removed from checkouts.")
+        if not found:
+            if enabled:
+                lines.append(f"    {package_name}")
+                print(f"{self.file_location}: {package_name} added to checkouts.")
+            else:
+                print(f"{self.file_location}: {package_name} not in checkouts.")
+
         newCheckoutsTxt = "\n".join(lines)
         if not newCheckoutsTxt.endswith("\n"):
             # Make sure the file ends with a newline.

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -60,9 +60,17 @@ class VersionsFile:
         We use strict=False to avoid a DuplicateOptionError.
         This happens in coredev 4.3 because we pin 'babel' and 'Babel'.
 
-        We need to combine all versions sections, like these:
+        We used to combine all versions sections, like these:
         ['versions', 'versions:python27']
+        That fixed https://github.com/plone/plone.releaser/issues/24
+        and was needed when we had packages like Archetypes which were only for
+        Python 2.  With Plone 6 I don't think we will need this.  We can still
+        have Python-version-specific sections, but that would be for external
+        packages.  I don't think we will be releasing Plone packages that are
+        for specific Python versions.  Or if we do, it would be overkill for
+        plone.releaser to support such a corner case.
 
+        So we do not want to report or edit anything except the versions section.
         """
         config = ConfigParser(interpolation=ExtendedInterpolation(), strict=False)
         with open(self.file_location) as f:
@@ -72,7 +80,7 @@ class VersionsFile:
             config["buildout"]["directory"] = os.getcwd()
         versions = {}
         for section in config.sections():
-            if "versions" in section.split(":"):
+            if section == "versions":
                 for package, version in config[section].items():
                     # Note: the package names are lower case.
                     versions[package] = version

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -4,8 +4,8 @@ from collections import UserDict
 from configparser import ConfigParser
 from configparser import ExtendedInterpolation
 
-import pathlib
 import os
+import pathlib
 import re
 
 

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -94,12 +94,6 @@ class VersionsFile:
             self.path.write_text(contents)
 
         newline = f"{package_name} = {new_version}"
-        # if package_name not in self:
-        #     contents += newline + "\n"
-        #     print(f"{self.file_location}: '{newline}' added.")
-        #     self.path.write_text(contents)
-        #     return
-
         line_reg = re.compile(rf"^{package_name.lower()} *=.*")
 
         def line_check(line):

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -114,8 +114,10 @@ class VersionsFile:
         if contents != new_contents:
             self.path.write_text(new_contents)
 
-    def get(self, package_name):
-        return self.__getitem__(package_name)
+    def get(self, package_name, default=None):
+        if package_name in self:
+            return self.__getitem__(package_name)
+        return default
 
     def set(self, package_name, new_version):
         return self.__setitem__(package_name, new_version)

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -65,7 +65,8 @@ class VersionsFile:
         with open(self.file_location) as f:
             config.read_file(f)
         # https://github.com/plone/plone.releaser/issues/42
-        config["buildout"]["directory"] = os.getcwd()
+        if config.has_section("buildout"):
+            config["buildout"]["directory"] = os.getcwd()
         versions = {}
         for section in config.sections():
             if "versions" in section.split(":"):

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -1,3 +1,4 @@
+from .utils import update_contents
 from collections import OrderedDict
 from collections import UserDict
 from configparser import ConfigParser
@@ -11,65 +12,6 @@ import re
 PATH_RE = re.compile(
     r"(\w+://)(.+@)*([\w\d\.]+)(:[\d]+){0,1}/(?P<path>.+(?=\.git))(\.git)"
 )
-
-
-def update_contents(contents, line_check, newline, filename, stop_check=None):
-    """Update contents to have a new line if needed.
-
-    * contents is some file contents
-    * line_check is a function we call to check if a line matches.
-    * newline is the line with which we replace the matched line.
-      This can be None to signal that the old line should be removed
-    * filename is used for reporting.
-    * stop_check is an optional function we call to check if we should stop
-      trying to match.
-
-    Returns the new contents.
-    """
-    lines = []
-    found = False
-    content_lines = contents.splitlines()
-    while content_lines:
-        line = content_lines.pop(0)
-        line = line.rstrip()
-        if stop_check is not None and stop_check(line):
-            # Put this line back.  We will handle this line and the other
-            # remaining lines outside of this loop.
-            content_lines.insert(0, line)
-            break
-        if not line_check(line):
-            lines.append(line)
-            continue
-        # We have a match.
-        if found:
-            # This is a duplicate, ignore the line.
-            continue
-        found = True
-        # Include this line only if we want it enabled.
-        if newline is None:
-            print(f"{filename}: '{line}' removed.")
-        elif line == newline:
-            lines.append(line)
-            print(f"{filename}: '{newline}' already there.")
-        else:
-            lines.append(newline)
-            print(f"{filename}: have set '{newline}'.")
-
-    if not found:
-        if newline is None:
-            print(f"{filename}: line not found.")
-        else:
-            if not lines[-1]:
-                # Insert before this last empty line.
-                lines.insert(-1, newline)
-            else:
-                lines.append(newline)
-            print(f"{filename}: '{newline}' added.")
-
-    if content_lines:
-        lines.extend(content_lines)
-
-    return "\n".join(lines) + "\n"
 
 
 class Source:
@@ -167,7 +109,9 @@ class VersionsFile:
 
         def stop_check(line):
             # If we see this line, we should stop trying to match.
-            return line.startswith("[versionannotations]") or line.startswith("[versions:")
+            return line.startswith("[versionannotations]") or line.startswith(
+                "[versions:"
+            )
 
         # set version in contents.
         new_contents = update_contents(

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -197,6 +197,24 @@ def get_package_version(package_name, path=None):
     """Get package version from constraints/versions file.
 
     If no path is given, we try several paths.
+
+    Note that versions with environment markers are ignored.
+    See https://peps.python.org/pep-0496/ explaining them.
+    The 99.99 percent use case of this part of plone.releaser is to get or set
+    versions for a Plone package, and after abandoning Python 2 we are unlikely
+    to need different versions of our core packages for different environments.
+
+    So in all the following cases, package version 1.0 is reported:
+
+    package==1.0
+    package==2.0; python_version=="3.11"
+
+    [versions]
+    package = 1.0
+    [versions:python311]
+    package = 2.0
+    [versions:python_version=="3.12"]
+    package = 3.0
     """
     for constraints in _get_constraints(path=path):
         if package_name not in constraints:
@@ -216,10 +234,8 @@ def set_package_version(package_name, new_version, path=None):
     but only if the package is already there: we do not want to add one package
     in three versions*.cfg files.
 
-    If you want it really fancy you can also add identifiers,
-    but that only gives valid results for pip files:
-
-    bin/manage set-package-version setuptools "65.7.0; python_version >= '3.0'" --path requirements.txt
+    If you want to add environment markers, like "python_version >= '3.0'",
+    please just edit the files yourself.
     """
     for constraints in _get_constraints(path=path):
         if package_name not in constraints:

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -11,6 +11,7 @@ from plone.releaser.buildout import Buildout
 from plone.releaser.buildout import CheckoutsFile
 from plone.releaser.buildout import VersionsFile
 from plone.releaser.package import Package
+from plone.releaser.pip import ConstraintsFile
 from progress.bar import Bar
 
 import keyring
@@ -127,7 +128,20 @@ def append_jenkins_build_number_to_package_version(jenkins_build_number):
 
 
 def set_package_version(version_file_path, package_name, new_version):
-    versions = VersionsFile(version_file_path)
+    """Pin package to new version in a versions file.
+
+    This can also be a pip constraints file.
+    If the package is not pinned yet, we add it.
+
+    If you want it really fancy you can also add identifiers,
+    but that only gives valid results for pip files:
+
+    bin/manage set-package-version requirements.txt setuptools "65.7.0; python_version >= '3.0'"
+    """
+    if version_file_path.endswith(".txt"):
+        versions = ConstraintsFile(version_file_path)
+    else:
+        versions = VersionsFile(version_file_path)
     versions.set(package_name, new_version)
 
 

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -163,7 +163,7 @@ def append_jenkins_build_number_to_package_version(jenkins_build_number):
     return new_version
 
 
-def set_package_version(package_name, new_version, version_file_path=None):
+def set_package_version(package_name, new_version, path=None):
     """Pin package to new version in a versions file.
 
     This can also be a pip constraints file.
@@ -174,10 +174,10 @@ def set_package_version(package_name, new_version, version_file_path=None):
     If you want it really fancy you can also add identifiers,
     but that only gives valid results for pip files:
 
-    bin/manage set-package-version setuptools "65.7.0; python_version >= '3.0'" requirements.txt
+    bin/manage set-package-version setuptools "65.7.0; python_version >= '3.0'" --path requirements.txt
     """
-    if version_file_path:
-        paths = [version_file_path]
+    if path:
+        paths = [path]
     else:
         paths = glob.glob("constraints*.txt") + glob.glob("versions*.cfg")
     for path in paths:

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -113,23 +113,43 @@ def changelog(**kwargs):
     build_unified_changelog(kwargs["start"], kwargs["end"])
 
 
-def check_checkout(package_name, path):
-    if path.endswith(".ini"):
-        checkouts = IniFile(path)
+def check_checkout(package_name, path=None):
+    """Check if package is in the checkouts.
+
+    If no path is given, we try several paths:
+    both checkouts.cfg and mxdev.ini.
+    """
+    if path:
+        paths = [path]
     else:
-        checkouts = CheckoutsFile(path)
-    if package_name not in checkouts:
-        print(f"No, your package {package_name} is NOT on auto checkout.")
-        sys.exit(1)
-    print(f"YES, your package {package_name} is on auto checkout.")
+        paths = glob.glob("mxdev.ini") + glob.glob("checkouts.cfg")
+    for path in paths:
+        if path.endswith(".ini"):
+            checkouts = IniFile(path)
+        else:
+            checkouts = CheckoutsFile(path)
+        if package_name not in checkouts:
+            print(f"No, your package {package_name} is NOT on auto checkout in {path}.")
+        else:
+            print(f"YES, your package {package_name} is on auto checkout in {path}.")
 
 
-def remove_checkout(package_name, path):
-    if path.endswith(".ini"):
-        checkouts = IniFile(path)
+def remove_checkout(package_name, path=None):
+    """Remove package from auto checkouts.
+
+    If no path is given, we try several paths:
+    both checkouts.cfg and mxdev.ini.
+    """
+    if path:
+        paths = [path]
     else:
-        checkouts = CheckoutsFile(path)
-    checkouts.remove(package_name)
+        paths = glob.glob("mxdev.ini") + glob.glob("checkouts.cfg")
+    for path in paths:
+        if path.endswith(".ini"):
+            checkouts = IniFile(path)
+        else:
+            checkouts = CheckoutsFile(path)
+        checkouts.remove(package_name)
 
 
 def append_jenkins_build_number_to_package_version(jenkins_build_number):

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -152,6 +152,24 @@ def remove_checkout(package_name, path=None):
         checkouts.remove(package_name)
 
 
+def add_checkout(package_name, path=None):
+    """Add package to auto checkouts.
+
+    If no path is given, we try several paths:
+    both checkouts.cfg and mxdev.ini.
+    """
+    if path:
+        paths = [path]
+    else:
+        paths = glob.glob("mxdev.ini") + glob.glob("checkouts.cfg")
+    for path in paths:
+        if path.endswith(".ini"):
+            checkouts = IniFile(path)
+        else:
+            checkouts = CheckoutsFile(path)
+        checkouts.add(package_name)
+
+
 def append_jenkins_build_number_to_package_version(jenkins_build_number):
     from zest.releaser.utils import cleanup_version
     from zest.releaser.vcs import BaseVersionControl
@@ -202,6 +220,7 @@ class Manage:
                 changelog,
                 check_checkout,
                 remove_checkout,
+                add_checkout,
                 append_jenkins_build_number_to_package_version,
                 set_package_version,
                 jenkins_report,

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -194,7 +194,7 @@ def _get_constraints(path=None):
 
 
 def get_package_version(package_name, path=None):
-    """Get package version fron constraints/versions file.
+    """Get package version from constraints/versions file.
 
     If no path is given, we try several paths.
     """
@@ -213,7 +213,7 @@ def set_package_version(package_name, new_version, path=None):
     If the package is not pinned yet, we add it.
 
     If no path is given, we try several paths and set the version in all of them,
-    bu only if the package is already there: we do not want to add one package
+    but only if the package is already there: we do not want to add one package
     in three versions*.cfg files.
 
     If you want it really fancy you can also add identifiers,

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -12,10 +12,12 @@ from plone.releaser.buildout import CheckoutsFile
 from plone.releaser.buildout import VersionsFile
 from plone.releaser.package import Package
 from plone.releaser.pip import ConstraintsFile
+from plone.releaser.pip import IniFile
 from progress.bar import Bar
 
 import keyring
 import time
+import sys
 
 
 # TODO
@@ -111,9 +113,22 @@ def changelog(**kwargs):
 
 
 def check_checkout(package_name, path):
-    if package_name not in CheckoutsFile(path):
-        msg = "Your package {0} is not on auto-checkout section"
-        raise KeyError(msg.format(package_name))
+    if path.endswith(".ini"):
+        checkouts = IniFile(path)
+    else:
+        checkouts = CheckoutsFile(path)
+    if package_name not in checkouts:
+        print(f"No, your package {package_name} is NOT on auto checkout.")
+        sys.exit(1)
+    print(f"YES, your package {package_name} is on auto checkout.")
+
+
+def remove_checkout(package_name, path):
+    if path.endswith(".ini"):
+        checkouts = IniFile(path)
+    else:
+        checkouts = CheckoutsFile(path)
+    checkouts.remove(package_name)
 
 
 def append_jenkins_build_number_to_package_version(jenkins_build_number):
@@ -156,6 +171,7 @@ class Manage:
                 pulls,
                 changelog,
                 check_checkout,
+                remove_checkout,
                 append_jenkins_build_number_to_package_version,
                 set_package_version,
                 jenkins_report,

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -198,7 +198,7 @@ def get_package_version(package_name, path=None):
 
     If no path is given, we try several paths.
     """
-    for constraints in _get_constraints(path=None):
+    for constraints in _get_constraints(path=path):
         if package_name not in constraints:
             print(f"{constraints.file_location}: {package_name} missing.")
             continue
@@ -221,7 +221,7 @@ def set_package_version(package_name, new_version, path=None):
 
     bin/manage set-package-version setuptools "65.7.0; python_version >= '3.0'" --path requirements.txt
     """
-    for constraints in _get_constraints(path=None):
+    for constraints in _get_constraints(path=path):
         if package_name not in constraints:
             if path is None:
                 print(f"{constraints.file_location}: {package_name} missing.")

--- a/plone/releaser/package.py
+++ b/plone/releaser/package.py
@@ -50,7 +50,6 @@ def buildout_coredev():
 
 
 class Package:
-
     # A reference to an plone.releaser.buildout.Buildout instance
     buildout = None
 

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -1,3 +1,4 @@
+from .utils import update_contents
 from collections import UserDict
 from configparser import ConfigParser
 from configparser import ExtendedInterpolation
@@ -56,22 +57,19 @@ class ConstraintsFile:
             self.path.write_text(contents)
 
         newline = f"{package_name}=={new_version}"
-        if package_name not in self:
-            contents += newline + "\n"
-            print(f"{self.file_location}: '{newline}' added.")
-            self.path.write_text(contents)
-            return
+        line_reg = re.compile(rf"^{package_name.lower()}==.*")
 
-        reg = re.compile(
-            rf"^{package_name} ?==.*$",
-            re.MULTILINE,
+        def line_check(line):
+            # Look for 'package name==version' on a line of its own,
+            # no whitespace in front.
+            return line_reg.match(line)
+
+        # set version in contents.
+        new_contents = update_contents(
+            contents, line_check, newline, self.file_location
         )
-        new_contents = reg.sub(newline, contents)
         if contents != new_contents:
-            print(f"{self.file_location}: have set '{newline}'.")
             self.path.write_text(new_contents)
-            return
-        print(f"{self.file_location}: '{newline}' already there.")
 
     def get(self, package_name):
         return self.__getitem__(package_name)

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -67,11 +67,11 @@ class ConstraintsFile:
             self.path.write_text(contents)
 
         newline = f"{package_name}=={new_version}"
-        line_reg = re.compile(rf"^{package_name.lower()}==.*")
+        # Look for 'package name==version' on a line of its own,
+        # no whitespace, no environment markers.
+        line_reg = re.compile(rf"^{package_name.lower()}==[^;]*$")
 
         def line_check(line):
-            # Look for 'package name==version' on a line of its own,
-            # no whitespace in front.
             return line_reg.match(line)
 
         # set version in contents.

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -53,17 +53,25 @@ class ConstraintsFile:
         contents = self.path.read_text()
         if not contents.endswith("\n"):
             contents += "\n"
+            self.path.write_text(contents)
 
         newline = f"{package_name}=={new_version}"
         if package_name not in self:
             contents += newline + "\n"
+            print(f"{self.file_location}: '{newline}' added.")
+            self.path.write_text(contents)
+            return
 
         reg = re.compile(
             rf"^{package_name} ?==.*$",
             re.MULTILINE,
         )
         new_contents = reg.sub(newline, contents)
-        self.path.write_text(new_contents)
+        if contents != new_contents:
+            print(f"{self.file_location}: have set '{newline}'.")
+            self.path.write_text(new_contents)
+            return
+        print(f"{self.file_location}: '{newline}' already there.")
 
     def get(self, package_name):
         return self.__getitem__(package_name)
@@ -131,6 +139,7 @@ class IniFile(UserDict):
         contents = self.path.read_text()
         if not contents.endswith("\n"):
             contents += "\n"
+            self.path.write_text(contents)
 
         lines = []
         found_package = False

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -1,6 +1,7 @@
 from collections import UserDict
 from configparser import ConfigParser
 from configparser import ExtendedInterpolation
+from functools import cached_property
 
 import pathlib
 import re
@@ -19,7 +20,7 @@ class ConstraintsFile:
         self.file_location = file_location
         self.path = pathlib.Path(self.file_location).resolve()
 
-    @property
+    @cached_property
     def constraints(self):
         """Read the constraints."""
         contents = self.path.read_text()

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -54,11 +54,7 @@ class ConstraintsFile:
         if not contents.endswith("\n"):
             contents += "\n"
 
-        # Should we use '==' or ' == '?  Use spaces when more than half already
-        # uses them.
         newline = f"{package_name}=={new_version}"
-        if contents.count(" == ") > contents.count("==") / 2:
-            newline = newline.replace("==", " == ")
         if package_name not in self:
             contents += newline + "\n"
 

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -1,0 +1,63 @@
+import pathlib
+import re
+
+
+class ConstraintsFile:
+    def __init__(self, file_location):
+        self.file_location = file_location
+        self.path = pathlib.Path(self.file_location).resolve()
+
+    @property
+    def constraints(self):
+        """Read the constraints."""
+        contents = self.path.read_text()
+        constraints = {}
+        for line in contents.splitlines():
+            line = line.strip()
+            if line.startswith("#"):
+                continue
+            if "==" not in line:
+                # We might want to support e.g. '>=', but for now keep it simple.
+                continue
+            package = line.split("==")[0].strip().lower()
+            version = line.split("==")[1].strip()
+            # The line could also contain identifiers like this:
+            # "; python_version >= '3.0'"
+            # But currently I think we really only need the package name,
+            # and not even the version.  Let's use the entire rest of the line.
+            constraints[package] = version
+        return constraints
+
+    def __contains__(self, package_name):
+        return package_name.lower() in self.constraints
+
+    def __getitem__(self, package_name):
+        if package_name in self:
+            return self.constraints.get(package_name.lower())
+        raise KeyError
+
+    def __setitem__(self, package_name, new_version):
+        contents = self.path.read_text()
+        if not contents.endswith("\n"):
+            contents += "\n"
+
+        # Should we use '==' or ' == '?  Use spaces when more than half already
+        # uses them.
+        newline = f"{package_name}=={new_version}"
+        if contents.count(" == ") > contents.count("==") / 2:
+            newline = newline.replace("==", " == ")
+        if package_name not in self:
+            contents += newline + "\n"
+
+        reg = re.compile(
+            rf"^{package_name} ?==.*$",
+            re.MULTILINE,
+        )
+        new_contents = reg.sub(newline, contents)
+        self.path.write_text(new_contents)
+
+    def get(self, package_name):
+        return self.__getitem__(package_name)
+
+    def set(self, package_name, new_version):
+        return self.__setitem__(package_name, new_version)

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -83,6 +83,7 @@ class IniFile(UserDict):
     For mxdev: set 'use = false'.
     The default is in 'settings': 'default-use'.
     """
+
     def __init__(self, file_location):
         self.file_location = file_location
         self.path = pathlib.Path(self.file_location).resolve()
@@ -124,10 +125,10 @@ class IniFile(UserDict):
         else:
             use = False
         if use and enabled:
-            print(f"{package_name} is already used as checkout.")
+            print(f"{self.file_location}: {package_name} already in checkouts.")
             return
         if not use and not enabled:
-            print(f"{package_name} is not used as checkout.")
+            print(f"{self.file_location}: {package_name} not in checkouts.")
             return
 
         contents = self.path.read_text()
@@ -150,12 +151,18 @@ class IniFile(UserDict):
                 continue
             if line == "" or line.startswith("["):
                 # A new section is starting.
-                if self.default_use and not enabled:
-                    # We need to explicitly disable it.
-                    lines.append("use = false")
-                elif not self.default_use and enabled:
-                    # We need to explicitly enable it.
-                    lines.append("use = true")
+                if not enabled:
+                    if self.default_use:
+                        # We need to explicitly disable it.
+                        lines.append("use = false")
+                    print(
+                        f"{self.file_location}: {package_name} removed from checkouts."
+                    )
+                else:
+                    if not self.default_use:
+                        # We need to explicitly enable it.
+                        lines.append("use = true")
+                    print(f"{self.file_location}: {package_name} added to checkouts.")
                 # We are done with the section for this package name.
                 found_package = False
                 # We still need to append the original line.

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -3,6 +3,7 @@ from plone.releaser.buildout import CheckoutsFile
 from plone.releaser.buildout import SourcesFile
 from plone.releaser.buildout import VersionsFile
 from plone.releaser.pip import ConstraintsFile
+from plone.releaser.pip import IniFile
 from plone.releaser.pypi import can_user_release_package_to_pypi
 from zest.releaser import pypi
 from zest.releaser.utils import ask
@@ -306,7 +307,14 @@ def update_versions(package_name, new_version):
 
 
 def remove_from_checkouts(package_name):
-    print("Removing package from checkouts.cfg")
-    path = os.path.join(os.getcwd(), "../../checkouts.cfg")
-    checkouts = CheckoutsFile(path)
-    checkouts.remove(package_name)
+    print("Removing package from checkouts")
+    cwd = pathlib.Path.cwd()
+    coredev_dir = (cwd / os.pardir / os.pardir).resolve()
+    checkouts_file = coredev_dir / "checkouts.cfg"
+    if checkouts_file.exists():
+        checkouts = CheckoutsFile(checkouts_file)
+        checkouts.remove(package_name)
+    checkouts_file = coredev_dir / "mxdev.ini"
+    if checkouts_file.exists():
+        checkouts = IniFile(checkouts_file)
+        checkouts.remove(package_name)

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -2,6 +2,7 @@ from copy import copy
 from plone.releaser.buildout import CheckoutsFile
 from plone.releaser.buildout import SourcesFile
 from plone.releaser.buildout import VersionsFile
+from plone.releaser.pip import ConstraintsFile
 from plone.releaser.pypi import can_user_release_package_to_pypi
 from zest.releaser import pypi
 from zest.releaser.utils import ask
@@ -286,11 +287,19 @@ def update_versions(package_name, new_version):
     # Update version
     print("Updating buildout versions")
     cwd = pathlib.Path.cwd()
-    buildout_dir = (cwd / os.pardir / os.pardir).resolve()
+    coredev_dir = (cwd / os.pardir / os.pardir).resolve()
     # In coredev 6.0 we have versions.cfg, versions-ecosystem.cfg, versions-extra.cfg.
-    for filename in glob.glob("versions*.cfg", root_dir=buildout_dir):
-        path = buildout_dir / filename
+    for filename in glob.glob("versions*.cfg", root_dir=coredev_dir):
+        path = coredev_dir / filename
         versions = VersionsFile(path)
+        if package_name in versions:
+            print(f"Updating {filename}")
+            versions.set(package_name, new_version)
+
+    # We may have pip constraints files to update.
+    for filename in glob.glob("constraints*.txt", root_dir=coredev_dir):
+        path = coredev_dir / filename
+        versions = ConstraintsFile(path)
         if package_name in versions:
             print(f"Updating {filename}")
             versions.set(package_name, new_version)

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -9,7 +9,9 @@ from zest.releaser.utils import read_text_file
 from zest.releaser.utils import write_text_file
 
 import git
+import glob
 import os
+import pathlib
 import sys
 import textwrap
 
@@ -282,10 +284,16 @@ def update_other_core_branches(data):
 
 def update_versions(package_name, new_version):
     # Update version
-    print("Updating versions.cfg")
-    path = os.path.join(os.getcwd(), "../../versions.cfg")
-    versions = VersionsFile(path)
-    versions.set(package_name, new_version)
+    print("Updating buildout versions")
+    cwd = pathlib.Path.cwd()
+    buildout_dir = (cwd / os.pardir / os.pardir).resolve()
+    # In coredev 6.0 we have versions.cfg, versions-ecosystem.cfg, versions-extra.cfg.
+    for filename in glob.glob("versions*.cfg", root_dir=buildout_dir):
+        path = buildout_dir / filename
+        versions = VersionsFile(path)
+        if package_name in versions:
+            print(f"Updating {filename}")
+            versions.set(package_name, new_version)
 
 
 def remove_from_checkouts(package_name):

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -178,14 +178,10 @@ def check_pypi_access(data):
     env_var = "PLONE_RELEASER_CHECK_PYPI_ACCESS"
     try:
         if int(os.getenv(env_var, 1)) == 0:
-            print(
-                f"{env_var} variable set to zero: not checking pypi release rights."
-            )
+            print(f"{env_var} variable set to zero: not checking pypi release rights.")
             return
     except (TypeError, ValueError, AttributeError):
-        print(
-            f"ERROR: could not parse {env_var} env var. Ignoring it."
-        )
+        print(f"ERROR: could not parse {env_var} env var. Ignoring it.")
 
     section = os.getenv("TWINE_REPOSITORY", "pypi")
     pypi_user = pypi.PypiConfig().config.get(section, "username")

--- a/plone/releaser/tests/input/constraints.txt
+++ b/plone/releaser/tests/input/constraints.txt
@@ -1,0 +1,12 @@
+# We should not touch this.
+-c https://zopefoundation.github.io/Zope/releases/5.8.3/constraints.txt
+# comment==1.0
+annotated==1.0
+CamelCase==1.0
+duplicate==1.0
+duplicate==1.0
+lowercase==1.0
+package==1.0
+pyspecific==1.0
+pyspecific==2.0; python_version=="3.12"
+UPPERCASE==1.0

--- a/plone/releaser/tests/input/versions.cfg
+++ b/plone/releaser/tests/input/versions.cfg
@@ -1,0 +1,18 @@
+[buildout]
+# We should not touch this.
+extends = https://zopefoundation.github.io/Zope/releases/5.8.3/versions.cfg
+
+[versions]
+# comment = 1.0
+annotated = 1.0
+duplicate = 1.0
+duplicate = 1.0
+package = 1.0
+pyspecific = 1.0
+
+[versions:python312]
+pyspecific = 2.0
+
+[versionannotations]
+annotated =
+    annotated = 1.1 conflicts with package = 1.1

--- a/plone/releaser/tests/input/versions.cfg
+++ b/plone/releaser/tests/input/versions.cfg
@@ -5,10 +5,13 @@ extends = https://zopefoundation.github.io/Zope/releases/5.8.3/versions.cfg
 [versions]
 # comment = 1.0
 annotated = 1.0
+CamelCase = 1.0
 duplicate = 1.0
 duplicate = 1.0
+lowercase = 1.0
 package = 1.0
 pyspecific = 1.0
+UPPERCASE = 1.0
 
 [versions:python312]
 pyspecific = 2.0

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -1,0 +1,61 @@
+from plone.releaser.buildout import VersionsFile
+
+import pathlib
+import pytest
+
+
+TESTS_DIR = pathlib.Path(__file__).parent
+INPUT_DIR = TESTS_DIR / "input"
+VERSIONS_FILE = INPUT_DIR / "versions.cfg"
+
+
+def test_versions_file_versions():
+    vf = VersionsFile(VERSIONS_FILE)
+    # All versions are reported lowercased.
+    assert vf.versions == {
+        "annotated": "1.0",
+        "camelcase": "1.0",
+        "duplicate": "1.0",
+        "lowercase": "1.0",
+        "package": "1.0",
+        "pyspecific": "2.0",
+        "uppercase": "1.0",
+    }
+
+
+def test_versions_file_contains():
+    vf = VersionsFile(VERSIONS_FILE)
+    assert "package" in vf
+    assert "nope" not in vf
+    # We compare case insensitively.
+    # Let's try all combinations
+    assert "camelcase" in vf
+    assert "CamelCase" in vf
+    assert "CAMELCASE" in vf
+    assert "lowercase" in vf
+    assert "LowerCase" in vf
+    assert "LOWERCASE" in vf
+    assert "uppercase" in vf
+    assert "UpperCase" in vf
+    assert "UPPERCASE" in vf
+
+
+def test_versions_file_get():
+    vf = VersionsFile(VERSIONS_FILE)
+    assert vf.get("package") == "1.0"
+    assert vf["package"] == "1.0"
+    with pytest.raises(KeyError):
+        vf["nope"]
+    assert vf.get("nope") is None
+    assert vf.get("nope", "hello") == "hello"
+    # We compare case insensitively.
+    # Let's try all combinations
+    assert vf["camelcase"] == "1.0"
+    assert vf["CamelCase"] == "1.0"
+    assert vf["CAMELCASE"] == "1.0"
+    assert vf["lowercase"] == "1.0"
+    assert vf["LowerCase"] == "1.0"
+    assert vf["LOWERCASE"] == "1.0"
+    assert vf["uppercase"] == "1.0"
+    assert vf["UpperCase"] == "1.0"
+    assert vf["UPPERCASE"] == "1.0"

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -19,7 +19,7 @@ def test_versions_file_versions():
         "duplicate": "1.0",
         "lowercase": "1.0",
         "package": "1.0",
-        "pyspecific": "2.0",
+        "pyspecific": "1.0",
         "uppercase": "1.0",
     }
 
@@ -75,3 +75,18 @@ def test_versions_file_set_normal(tmp_path):
     vf["package"] = "3.0"
     vf = VersionsFile(copy_path)
     assert vf.get("package") == "3.0"
+
+
+def test_versions_file_set_ignore_markers(tmp_path):
+    # [versions:python312] pins 'pyspecific = 2.0'.
+    # We do not report or change this section.
+    copy_path = tmp_path / "versions.cfg"
+    shutil.copyfile(VERSIONS_FILE, copy_path)
+    vf = VersionsFile(copy_path)
+    assert "pyspecific = 2.0" in copy_path.read_text()
+    assert vf.get("pyspecific") == "1.0"
+    vf.set("package", "1.1")
+    # Let's read it fresh, for good measure.
+    vf = VersionsFile(copy_path)
+    assert vf.get("package") == "1.1"
+    assert "pyspecific = 2.0" in copy_path.read_text()

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -90,3 +90,17 @@ def test_versions_file_set_ignore_markers(tmp_path):
     vf = VersionsFile(copy_path)
     assert vf.get("package") == "1.1"
     assert "pyspecific = 2.0" in copy_path.read_text()
+
+
+def test_versions_file_set_cleanup_duplicates(tmp_path):
+    copy_path = tmp_path / "versions.cfg"
+    shutil.copyfile(VERSIONS_FILE, copy_path)
+    assert copy_path.read_text().count("duplicate = 1.0") == 2
+    vf = VersionsFile(copy_path)
+    assert vf.get("duplicate") == "1.0"
+    vf.set("duplicate", "2.0")
+    # Let's read it fresh, for good measure.
+    vf = VersionsFile(copy_path)
+    assert vf.get("duplicate") == "2.0"
+    assert copy_path.read_text().count("duplicate = 2.0") == 1
+    assert copy_path.read_text().count("duplicate = 1.0") == 0

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -2,6 +2,7 @@ from plone.releaser.buildout import VersionsFile
 
 import pathlib
 import pytest
+import shutil
 
 
 TESTS_DIR = pathlib.Path(__file__).parent
@@ -59,3 +60,14 @@ def test_versions_file_get():
     assert vf["uppercase"] == "1.0"
     assert vf["UpperCase"] == "1.0"
     assert vf["UPPERCASE"] == "1.0"
+
+
+def test_versions_file_set(tmp_path):
+    # When we set a version, the file changes, so we work on a copy.
+    shutil.copyfile(VERSIONS_FILE, tmp_path / "versions.cfg")
+    vf = VersionsFile(tmp_path / "versions.cfg")
+    assert vf.get("package") == "1.0"
+    vf.set("package", "2.0")
+    assert vf.get("package") == "2.0"
+    vf["package"] = "3.0"
+    assert vf.get("package") == "3.0"

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -62,12 +62,16 @@ def test_versions_file_get():
     assert vf["UPPERCASE"] == "1.0"
 
 
-def test_versions_file_set(tmp_path):
+def test_versions_file_set_normal(tmp_path):
     # When we set a version, the file changes, so we work on a copy.
-    shutil.copyfile(VERSIONS_FILE, tmp_path / "versions.cfg")
-    vf = VersionsFile(tmp_path / "versions.cfg")
+    copy_path = tmp_path / "versions.cfg"
+    shutil.copyfile(VERSIONS_FILE, copy_path)
+    vf = VersionsFile(copy_path)
     assert vf.get("package") == "1.0"
     vf.set("package", "2.0")
+    # Let's read it fresh, for good measure.
+    vf = VersionsFile(copy_path)
     assert vf.get("package") == "2.0"
     vf["package"] = "3.0"
+    vf = VersionsFile(copy_path)
     assert vf.get("package") == "3.0"

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -85,10 +85,10 @@ def test_versions_file_set_ignore_markers(tmp_path):
     vf = VersionsFile(copy_path)
     assert "pyspecific = 2.0" in copy_path.read_text()
     assert vf.get("pyspecific") == "1.0"
-    vf.set("package", "1.1")
+    vf.set("pyspecific", "1.1")
     # Let's read it fresh, for good measure.
     vf = VersionsFile(copy_path)
-    assert vf.get("package") == "1.1"
+    assert vf.get("pyspecific") == "1.1"
     assert "pyspecific = 2.0" in copy_path.read_text()
 
 

--- a/plone/releaser/tests/test_pip.py
+++ b/plone/releaser/tests/test_pip.py
@@ -78,8 +78,8 @@ def test_constraints_file_set_normal(tmp_path):
 
 
 def test_constraints_file_set_ignore_markers(tmp_path):
-    # [constraints:python312] pins 'pyspecific = 2.0'.
-    # We do not report or change this section.
+    # pyspecific==2.0; python_version=="3.12"
+    # version pins that have a specific `python_version` are not changed.
     copy_path = tmp_path / "constraints.txt"
     shutil.copyfile(CONSTRAINTS_FILE, copy_path)
     cf = ConstraintsFile(copy_path)

--- a/plone/releaser/tests/test_pip.py
+++ b/plone/releaser/tests/test_pip.py
@@ -1,0 +1,106 @@
+from plone.releaser.pip import ConstraintsFile
+
+import pathlib
+import pytest
+import shutil
+
+
+TESTS_DIR = pathlib.Path(__file__).parent
+INPUT_DIR = TESTS_DIR / "input"
+CONSTRAINTS_FILE = INPUT_DIR / "constraints.txt"
+
+
+def test_constraints_file_constraints():
+    cf = ConstraintsFile(CONSTRAINTS_FILE)
+    # All constraints are reported lowercased.
+    assert cf.constraints == {
+        "annotated": "1.0",
+        "camelcase": "1.0",
+        "duplicate": "1.0",
+        "lowercase": "1.0",
+        "package": "1.0",
+        "pyspecific": "1.0",
+        "uppercase": "1.0",
+    }
+
+
+def test_constraints_file_contains():
+    cf = ConstraintsFile(CONSTRAINTS_FILE)
+    assert "package" in cf
+    assert "nope" not in cf
+    # We compare case insensitively.
+    # Let's try all combinations
+    assert "camelcase" in cf
+    assert "CamelCase" in cf
+    assert "CAMELCASE" in cf
+    assert "lowercase" in cf
+    assert "LowerCase" in cf
+    assert "LOWERCASE" in cf
+    assert "uppercase" in cf
+    assert "UpperCase" in cf
+    assert "UPPERCASE" in cf
+
+
+def test_constraints_file_get():
+    cf = ConstraintsFile(CONSTRAINTS_FILE)
+    assert cf.get("package") == "1.0"
+    assert cf["package"] == "1.0"
+    with pytest.raises(KeyError):
+        cf["nope"]
+    assert cf.get("nope") is None
+    assert cf.get("nope", "hello") == "hello"
+    # We compare case insensitively.
+    # Let's try all combinations
+    assert cf["camelcase"] == "1.0"
+    assert cf["CamelCase"] == "1.0"
+    assert cf["CAMELCASE"] == "1.0"
+    assert cf["lowercase"] == "1.0"
+    assert cf["LowerCase"] == "1.0"
+    assert cf["LOWERCASE"] == "1.0"
+    assert cf["uppercase"] == "1.0"
+    assert cf["UpperCase"] == "1.0"
+    assert cf["UPPERCASE"] == "1.0"
+
+
+def test_constraints_file_set_normal(tmp_path):
+    # When we set a version, the file changes, so we work on a copy.
+    copy_path = tmp_path / "constraints.txt"
+    shutil.copyfile(CONSTRAINTS_FILE, copy_path)
+    cf = ConstraintsFile(copy_path)
+    assert cf.get("package") == "1.0"
+    cf.set("package", "2.0")
+    # Let's read it fresh, for good measure.
+    cf = ConstraintsFile(copy_path)
+    assert cf.get("package") == "2.0"
+    cf["package"] = "3.0"
+    cf = ConstraintsFile(copy_path)
+    assert cf.get("package") == "3.0"
+
+
+def test_constraints_file_set_ignore_markers(tmp_path):
+    # [constraints:python312] pins 'pyspecific = 2.0'.
+    # We do not report or change this section.
+    copy_path = tmp_path / "constraints.txt"
+    shutil.copyfile(CONSTRAINTS_FILE, copy_path)
+    cf = ConstraintsFile(copy_path)
+    assert "pyspecific==2.0" in copy_path.read_text()
+    assert cf.get("pyspecific") == "1.0"
+    cf.set("package", "1.1")
+    # Let's read it fresh, for good measure.
+    cf = ConstraintsFile(copy_path)
+    assert cf.get("package") == "1.1"
+    assert "pyspecific==2.0" in copy_path.read_text()
+
+
+def test_constraints_file_set_cleanup_duplicates(tmp_path):
+    copy_path = tmp_path / "constraints.txt"
+    shutil.copyfile(CONSTRAINTS_FILE, copy_path)
+    assert copy_path.read_text().count("duplicate==1.0") == 2
+    cf = ConstraintsFile(copy_path)
+    assert cf.get("duplicate") == "1.0"
+    cf.set("duplicate", "2.0")
+    # Let's read it fresh, for good measure.
+    cf = ConstraintsFile(copy_path)
+    assert cf.get("duplicate") == "2.0"
+    assert copy_path.read_text().count("duplicate==2.0") == 1
+    assert copy_path.read_text().count("duplicate==1.0") == 0

--- a/plone/releaser/tests/test_pip.py
+++ b/plone/releaser/tests/test_pip.py
@@ -85,10 +85,10 @@ def test_constraints_file_set_ignore_markers(tmp_path):
     cf = ConstraintsFile(copy_path)
     assert "pyspecific==2.0" in copy_path.read_text()
     assert cf.get("pyspecific") == "1.0"
-    cf.set("package", "1.1")
+    cf.set("pyspecific", "1.1")
     # Let's read it fresh, for good measure.
     cf = ConstraintsFile(copy_path)
-    assert cf.get("package") == "1.1"
+    assert cf.get("pyspecific") == "1.1"
     assert "pyspecific==2.0" in copy_path.read_text()
 
 

--- a/plone/releaser/tests/test_utils.py
+++ b/plone/releaser/tests/test_utils.py
@@ -17,22 +17,26 @@ def test_update_contents_newline_at_end():
     assert update_contents("", lambda x: True, "", "") == "\n"
 
 
-def test_update_contents_versions_match():
+def test_update_contents_versions_match(capsys):
     def line_check(line):
         return line.startswith("package =")
 
-    result = update_contents(VERSIONS, line_check, "package = 2.0", "")
+    result = update_contents(VERSIONS, line_check, "package = 2.0", "file")
     assert "package = 2.0" in result
     assert "package = 1.0" not in result
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "file: have set 'package = 2.0'."
 
 
-def test_update_contents_versions_add_at_end():
+def test_update_contents_versions_add_at_end(capsys):
     def line_check(line):
         return line.startswith("new =")
 
-    result = update_contents(VERSIONS, line_check, "new = 2.0", "")
+    result = update_contents(VERSIONS, line_check, "new = 2.0", "file")
     assert "new = 2.0" in result
     assert "new = 2.0" == result.splitlines()[-1]
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "file: 'new = 2.0' added."
 
 
 def test_update_contents_versions_add_before_markers():

--- a/plone/releaser/tests/test_utils.py
+++ b/plone/releaser/tests/test_utils.py
@@ -1,0 +1,64 @@
+from plone.releaser.utils import update_contents
+
+import pathlib
+
+
+TESTS_DIR = pathlib.Path(__file__).parent
+INPUT_DIR = TESTS_DIR / "input"
+# Sample buildout versions.cfg
+VERSIONS = (INPUT_DIR / "versions.cfg").read_text()
+
+
+def test_update_contents_empty():
+    assert update_contents("\n", lambda x: True, "", "") == "\n"
+
+
+def test_update_contents_newline_at_end():
+    assert update_contents("", lambda x: True, "", "") == "\n"
+
+
+def test_update_contents_versions_match():
+    def line_check(line):
+        return line.startswith("package =")
+
+    result = update_contents(VERSIONS, line_check, "package = 2.0", "")
+    assert "package = 2.0" in result
+    assert "package = 1.0" not in result
+
+
+def test_update_contents_versions_add_at_end():
+    def line_check(line):
+        return line.startswith("new =")
+
+    result = update_contents(VERSIONS, line_check, "new = 2.0", "")
+    assert "new = 2.0" in result
+    assert "new = 2.0" == result.splitlines()[-1]
+
+
+def test_update_contents_versions_add_before_markers():
+    def line_check(line):
+        return line.startswith("new =")
+
+    def stop_check(line):
+        # If we see this line, we should stop trying to match.
+        return line.startswith("[versions:")
+
+    result = update_contents(
+        VERSIONS, line_check, "new = 2.0", "", stop_check=stop_check
+    )
+    assert "new = 2.0" in result
+    assert result.index("new = 2.0") < result.index("[versions:")
+    lines = result.splitlines()
+    new_index = lines.index("new = 2.0")
+    # We have left a blank line.
+    assert lines[new_index + 1] == ""
+    assert lines[new_index + 2] == "[versions:python312]"
+
+
+def test_update_contents_versions_removes_duplicates():
+    def line_check(line):
+        return line.startswith("duplicate =")
+
+    result = update_contents(VERSIONS, line_check, "duplicate = 2.0", "")
+    assert "duplicate = 2.0" in result
+    assert result.count("duplicate =") == 1

--- a/plone/releaser/utils.py
+++ b/plone/releaser/utils.py
@@ -1,0 +1,57 @@
+def update_contents(contents, line_check, newline, filename, stop_check=None):
+    """Update contents to have a new line if needed.
+
+    * contents is some file contents
+    * line_check is a function we call to check if a line matches.
+    * newline is the line with which we replace the matched line.
+      This can be None to signal that the old line should be removed
+    * filename is used for reporting.
+    * stop_check is an optional function we call to check if we should stop
+      trying to match.
+
+    Returns the new contents.
+    """
+    lines = []
+    found = False
+    content_lines = contents.splitlines()
+    while content_lines:
+        line = content_lines.pop(0)
+        line = line.rstrip()
+        if stop_check is not None and stop_check(line):
+            # Put this line back.  We will handle this line and the other
+            # remaining lines outside of this loop.
+            content_lines.insert(0, line)
+            break
+        if not line_check(line):
+            lines.append(line)
+            continue
+        # We have a match.
+        if found:
+            # This is a duplicate, ignore the line.
+            continue
+        found = True
+        # Include this line only if we want it enabled.
+        if newline is None:
+            print(f"{filename}: '{line}' removed.")
+        elif line == newline:
+            lines.append(line)
+            print(f"{filename}: '{newline}' already there.")
+        else:
+            lines.append(newline)
+            print(f"{filename}: have set '{newline}'.")
+
+    if not found:
+        if newline is None:
+            print(f"{filename}: line not found.")
+        else:
+            if lines and not lines[-1]:
+                # Insert before this last empty line.
+                lines.insert(-1, newline)
+            else:
+                lines.append(newline)
+            print(f"{filename}: '{newline}' added.")
+
+    if content_lines:
+        lines.extend(content_lines)
+
+    return "\n".join(lines) + "\n"

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ setup(
         "zestreleaser.towncrier>=1.3.0",
         "docutils",
     ],
+    extras_requires={
+        "test": ["pytest"],
+    },
     entry_points={
         "console_scripts": ["manage = plone.releaser.manage:manage"],
         "zest.releaser.prereleaser.before": [

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 envlist =
     format
     lint
+    test
 
 [testenv]
 py_files = git ls-files "*.py"
@@ -62,3 +63,14 @@ deps =
     -c lint-requirements.txt
 commands =
     sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel --graph-output svg > dependencies.svg'
+
+[testenv:test]
+description = run the distribution tests
+use_develop = true
+skip_install = false
+constrain_package_deps = true
+deps =
+    pytest
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    pytest


### PR DESCRIPTION
Fixes issue #53.

I tried it out by releasing one package, while having a non-git `constraints.txt` and `mxdev.ini` in the coredev buildout.