### PR TITLE
Fix setting version for non-lowercase package.

### DIFF
--- a/news/58.bugfix
+++ b/news/58.bugfix
@@ -1,0 +1,3 @@
+Fix setting version for non-lowercase package.
+In the previous release this would add a duplicate line.
+[maurits]

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -99,7 +99,8 @@ class VersionsFile(BaseFile):
             self.path.write_text(contents)
 
         newline = f"{package_name} = {new_version}"
-        line_reg = re.compile(rf"^{package_name.lower()} *=.*")
+        # Search case insensitively.
+        line_reg = re.compile(rf"^{package_name} *=.*", flags=re.I)
 
         def line_check(line):
             # Look for the 'package name = version' on a line of its own,

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -57,7 +57,7 @@ class ConstraintsFile(BaseFile):
         newline = f"{package_name}=={new_version}"
         # Look for 'package name==version' on a line of its own,
         # no whitespace, no environment markers.
-        line_reg = re.compile(rf"^{package_name.lower()}==[^;]*$")
+        line_reg = re.compile(rf"^{package_name}==[^;]*$", flags=re.I)
 
         def line_check(line):
             return line_reg.match(line)

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -236,6 +236,19 @@ def test_versions_file_set_normal(tmp_path):
     vf["package"] = "3.0"
     vf = VersionsFile(copy_path)
     assert vf.get("package") == "3.0"
+    # How about packages that are not lowercase?
+    # ConfigParser reports all package names as lower case, so we don't know
+    # what their exact spelling is.  So whatever we pass on, should be used.
+    assert "CamelCase = 1.0" in copy_path.read_text()
+    assert copy_path.read_text().lower().count("camelcase") == 1
+    vf["CAMELcase"] = "1.1"
+    vf = VersionsFile(copy_path)
+    assert vf["camelCASE"] == "1.1"
+    assert vf["CaMeLcAsE"] == "1.1"
+    text = copy_path.read_text()
+    assert "CamelCase = 1.0" not in text
+    assert "CAMELcase = 1.1" in text
+    assert copy_path.read_text().lower().count("camelcase") == 1
 
 
 def test_versions_file_set_ignore_markers(tmp_path):

--- a/plone/releaser/tests/test_pip.py
+++ b/plone/releaser/tests/test_pip.py
@@ -158,6 +158,20 @@ def test_constraints_file_set_normal(tmp_path):
     cf["package"] = "3.0"
     cf = ConstraintsFile(copy_path)
     assert cf.get("package") == "3.0"
+    # How about packages that are not lowercase?
+    # Currently in ConstraintsFile we report all package names as lower case,
+    # so we don't know what their exact spelling is, which is what ConfigParser
+    # does for the Buildout versions file.  So whatever we pass on, should be used.
+    assert "CamelCase==1.0" in copy_path.read_text()
+    assert copy_path.read_text().lower().count("camelcase") == 1
+    cf["CAMELcase"] = "1.1"
+    cf = ConstraintsFile(copy_path)
+    assert cf["camelCASE"] == "1.1"
+    assert cf["CaMeLcAsE"] == "1.1"
+    text = copy_path.read_text()
+    assert "CamelCase==1.0" not in text
+    assert "CAMELcase==1.1" in text
+    assert copy_path.read_text().lower().count("camelcase") == 1
 
 
 def test_constraints_file_set_ignore_markers(tmp_path):


### PR DESCRIPTION
In the previous release this would add a duplicate line. Fixes https://github.com/plone/plone.releaser/issues/58