### PR TITLE
Fix missing changelog entries when running `bin/manage changelog`.

### DIFF
--- a/news/60.bugfix
+++ b/news/60.bugfix
@@ -1,0 +1,2 @@
+Fix missing changelog entries when running ``bin/manage changelog``.
+[maurits]

--- a/plone/releaser/changelog.py
+++ b/plone/releaser/changelog.py
@@ -149,7 +149,7 @@ class Changelog:
             if x.rawsource in HEADINGS:
                 return x.rawsource
             # Might be an old heading or unknown.
-            return OLD_HEADING_MAPPING.get(x.rawsource, "")
+            return OLD_HEADING_MAPPING.get(x.rawsource, "other")
 
         def is_list_item(x):
             return x.tagname == "list_item"

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -43,7 +43,14 @@ Bug fixes:
 )
 HEADERS = [BREAKING_TEXT, FEATURE_TEXT, BUGFIXES_TEXT]
 # Used by changelog.py:
-HEADINGS = ["Breaking changes:", "New features:", "Bug fixes:"]
+HEADINGS = [
+    "Breaking changes:",
+    "New features:",
+    "Bug fixes:",
+    "Documentation:",
+    "Tests",
+    "Internal:",
+]
 # For compatibility with previous names of the headers.
 INCOMPATIBILITIES_TEXT = """
 Incompatibilities:

--- a/plone/releaser/tests/input/changes.rst
+++ b/plone/releaser/tests/input/changes.rst
@@ -1,0 +1,32 @@
+Example changelog from plone.dexterity.
+At some point the bug fixes were missing, and the internal item was filed under bug fixes.
+See https://github.com/plone/plone.releaser/issues/60
+
+
+3.0.3 (2023-09-01)
+------------------
+
+Bug fixes:
+
+
+- Respect locally allowed types when pasting objects [cekk] (#146)
+- Fix a memory leak as reported in https://github.com/plone/Products.CMFPlone/issues/3829, changing interface declaration type as suggested by @d-maurer in https://github.com/plone/plone.dexterity/issues/186 [mamico] (#187)
+
+
+Internal:
+
+
+- Update configuration files.
+  [plone devs] (55bda5c9)
+
+
+3.0.2 (2023-03-14)
+------------------
+
+Bug fixes:
+
+
+- Type error is removed and none is returned.
+  In this modified version of the code, if no primary field adapter is found, the fieldname and field attributes are set to None.
+  The value property checks whether the field attribute is None, and returns None if it is, instead of raising an error.
+  [Coder-aadarsh] (#59)

--- a/plone/releaser/tests/test_changelog.py
+++ b/plone/releaser/tests/test_changelog.py
@@ -1,0 +1,26 @@
+from plone.releaser.changelog import Changelog
+
+import pathlib
+
+
+TESTS_DIR = pathlib.Path(__file__).parent
+INPUT_DIR = TESTS_DIR / "input"
+CHANGES_FILE = INPUT_DIR / "changes.rst"
+
+
+def test_get_changes():
+    cf = Changelog(CHANGES_FILE)
+    assert "3.0.2" in cf
+    assert "3.0.3" in cf
+    assert sorted(list(cf.get("3.0.3").keys())) == ["Bug fixes:", "Internal:", "other"]
+    assert cf.get_changes("3.0.3") == []
+    assert cf.get_changes("3.0.2") == [
+        "Bug fixes:",
+        "Respect locally allowed types when pasting objects [cekk] (#146)",
+        "Fix a memory leak as reported in "
+        "https://github.com/plone/Products.CMFPlone/issues/3829, changing interface "
+        "declaration type as suggested by @d-maurer in "
+        "https://github.com/plone/plone.dexterity/issues/186 [mamico] (#187)",
+        "Internal:",
+        "Update configuration files.\n[plone devs] (55bda5c9)",
+    ]


### PR DESCRIPTION
Fixes https://github.com/plone/plone.releaser/issues/60