### PR TITLE
Add bin/manage versions2constraints command.

### DIFF
--- a/news/3670.feature
+++ b/news/3670.feature
@@ -1,0 +1,2 @@
+Add bin/manage versions2constraints command.
+[maurits]

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -1,5 +1,6 @@
 from .base import BaseFile
 from .utils import update_contents
+from collections import defaultdict
 from collections import OrderedDict
 from configparser import ConfigParser
 from configparser import ExtendedInterpolation
@@ -54,9 +55,11 @@ class Source:
 
 
 class VersionsFile(BaseFile):
-    def __init__(self, file_location):
+    def __init__(self, file_location, with_markers=False):
         self.file_location = file_location
         self.path = pathlib.Path(self.file_location).resolve()
+        self.with_markers = with_markers
+        self.markers = set()
 
     @property
     def data(self):
@@ -76,6 +79,9 @@ class VersionsFile(BaseFile):
         plone.releaser to support such a corner case.
 
         So we do not want to report or edit anything except the versions section.
+
+        Ah, but we *do* need this information when translating to pip.
+        For that: set self.with_markers = True.
         """
         config = ConfigParser(interpolation=ExtendedInterpolation(), strict=False)
         with self.path.open() as f:
@@ -83,12 +89,31 @@ class VersionsFile(BaseFile):
         # https://github.com/plone/plone.releaser/issues/42
         if config.has_section("buildout"):
             config["buildout"]["directory"] = os.getcwd()
-        versions = {}
+        versions = defaultdict(list)
         for section in config.sections():
             if section == "versions":
                 for package, version in config[section].items():
                     # Note: the package names are lower case.
-                    versions[package] = version
+                    if not self.with_markers:
+                        versions[package] = version
+                    else:
+                        versions[package].append(version)
+            if not self.with_markers:
+                continue
+            parts = section.split(":")
+            if len(parts) != 2 or parts[0] != "versions":
+                continue
+            marker = parts[1]
+            self.markers.add(marker)
+            for package, version in config[section].items():
+                # Note: the package names are lower case.
+                versions[package].append((version, marker))
+
+        if self.with_markers:
+            # simplify
+            for package, version in versions.items():
+                if isinstance(version, list) and len(version) == 1:
+                    versions[package] = version[0]
         return versions
 
     def __setitem__(self, package_name, new_version):
@@ -98,6 +123,14 @@ class VersionsFile(BaseFile):
             contents += "\n"
             self.path.write_text(contents)
 
+        if isinstance(new_version, tuple):
+            new_version, marker = new_version
+            section = f"[versions:{marker}]"
+            if marker not in self.markers:
+                contents = f"{contents}\n{section}\n"
+                self.path.write_text(contents)
+        else:
+            section = "[versions]"
         newline = f"{package_name} = {new_version}"
         # Search case insensitively.
         line_reg = re.compile(rf"^{package_name} *=.*", flags=re.I)
@@ -107,15 +140,22 @@ class VersionsFile(BaseFile):
             # no whitespace in front.  Maybe whitespace in between.
             return line_reg.match(line)
 
+        def start_check(line):
+            # If we see this line, we start trying to match.
+            return line == section
+
         def stop_check(line):
             # If we see this line, we should stop trying to match.
-            return line.startswith("[versionannotations]") or line.startswith(
-                "[versions:"
-            )
+            return line.startswith("[")
 
         # set version in contents.
         new_contents = update_contents(
-            contents, line_check, newline, self.file_location, stop_check=stop_check
+            contents,
+            line_check,
+            newline,
+            self.file_location,
+            start_check=start_check,
+            stop_check=stop_check,
         )
         if contents != new_contents:
             self.path.write_text(new_contents)
@@ -134,6 +174,7 @@ class SourcesFile(BaseFile):
         # https://github.com/plone/mr.roboto/issues/89
         config["buildout"]["directory"] = os.getcwd()
         sources_dict = OrderedDict()
+        # I don't think we need to support [sources:marker].
         for name, value in config["sources"].items():
             source = Source.create_from_string(value)
             sources_dict[name.lower()] = source
@@ -150,6 +191,7 @@ class CheckoutsFile(BaseFile):
         with self.path.open() as f:
             config.read_file(f)
         config["buildout"]["directory"] = os.getcwd()
+        # I don't think we need to support [buildout:marker].
         checkouts = config.get("buildout", "auto-checkout")
         # Map from lower case to actual case, so we can find the package.
         mapping = {}

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -231,6 +231,28 @@ def set_package_version(package_name, new_version, path=None):
         constraints.set(package_name, new_version)
 
 
+def versions2constraints(path=None):
+    """Take a Buildout versions file and create a pip constraints file out of it.
+
+    If no path is given, we use versions*.cfg.
+    """
+    if path:
+        paths = [path]
+    else:
+        paths = glob.glob("versions*.cfg")
+    for path in paths:
+        versions = VersionsFile(path)
+        constraints_path = path.replace("versions", "constraints").replace(
+            ".cfg", ".txt"
+        )
+        constraints = ConstraintsFile(constraints_path)
+        if not constraints.path.exists():
+            with constraints.path.open("w") as myfile:
+                myfile.write("")
+        for package_name, version in versions.items():
+            constraints[package_name] = version
+
+
 class Manage:
     def __call__(self, **kwargs):
         parser = ArghParser()
@@ -247,6 +269,7 @@ class Manage:
                 set_package_version,
                 get_package_version,
                 jenkins_report,
+                versions2constraints,
             ]
         )
         parser.dispatch()

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -235,6 +235,24 @@ def versions2constraints(path=None):
     """Take a Buildout versions file and create a pip constraints file out of it.
 
     If no path is given, we use versions*.cfg.
+
+    Notes:
+    * This does not handle 'extends' yet.
+    * This does not handle [versions:pythonX] yet.
+
+    We could parse the file with Buildout.  This incorporates the 'extends',
+    but you lose versions information for other Python versions.
+
+    We could pass an option simple/full.
+    Maybe if a path is passed, we handle only that file in simple mode.
+    Without path, we grab versions.cfg and check 'extends' and other versions.
+
+    'extends = versions-extra.cfg' could be transformed to '-c constraints-extra.txt'
+
+    I think I need some more options in VersionsFile first:
+    - what to do with extends
+    - what to do with [versions:*]
+    - whether to turn it into a single constraints file.
     """
     if path:
         paths = [path]

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -260,13 +260,15 @@ def versions2constraints(*, path=None):
         paths = glob.glob("versions*.cfg")
     for path in paths:
         versions = VersionsFile(path)
-        constraints_path = path.replace("versions", "constraints").replace(
+        # Create path to constraints*.txt instead of versions*.cfg.
+        filename = str(path)[len(str(path.parent)) + 1:]
+        filename = filename.replace("versions", "constraints").replace(
             ".cfg", ".txt"
         )
+        constraints_path = path.parent / filename
         constraints = ConstraintsFile(constraints_path)
         if not constraints.path.exists():
-            with constraints.path.open("w") as myfile:
-                myfile.write("")
+            constraints.path.touch()
         for package_name, version in versions.items():
             constraints[package_name] = version
 

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -112,7 +112,7 @@ def _get_checkouts(path=None):
         yield checkouts
 
 
-def check_checkout(package_name, path=None):
+def check_checkout(package_name, *, path=None):
     """Check if package is in the checkouts.
 
     If no path is given, we try several paths:
@@ -126,7 +126,7 @@ def check_checkout(package_name, path=None):
             print(f"YES, your package {package_name} is on auto checkout in {loc}.")
 
 
-def remove_checkout(package_name, path=None):
+def remove_checkout(package_name, *, path=None):
     """Remove package from auto checkouts.
 
     If no path is given, we try several paths:
@@ -136,7 +136,7 @@ def remove_checkout(package_name, path=None):
         checkouts.remove(package_name)
 
 
-def add_checkout(package_name, path=None):
+def add_checkout(package_name, *, path=None):
     """Add package to auto checkouts.
 
     If no path is given, we try several paths:
@@ -175,7 +175,7 @@ def _get_constraints(path=None):
         yield constraints
 
 
-def get_package_version(package_name, path=None):
+def get_package_version(package_name, *, path=None):
     """Get package version from constraints/versions file.
 
     If no path is given, we try several paths.
@@ -206,7 +206,7 @@ def get_package_version(package_name, path=None):
         print(f"{constraints.file_location}: {package_name} {version}.")
 
 
-def set_package_version(package_name, new_version, path=None):
+def set_package_version(package_name, new_version, *, path=None):
     """Pin package to new version in a versions file.
 
     This can also be a pip constraints file.
@@ -231,7 +231,7 @@ def set_package_version(package_name, new_version, path=None):
         constraints.set(package_name, new_version)
 
 
-def versions2constraints(path=None):
+def versions2constraints(*, path=None):
     """Take a Buildout versions file and create a pip constraints file out of it.
 
     If no path is given, we use versions*.cfg.

--- a/plone/releaser/manage.py
+++ b/plone/releaser/manage.py
@@ -259,18 +259,13 @@ def versions2constraints(*, path=None):
     else:
         paths = glob.glob("versions*.cfg")
     for path in paths:
-        versions = VersionsFile(path)
+        versions = VersionsFile(path, with_markers=True)
         # Create path to constraints*.txt instead of versions*.cfg.
-        filename = str(path)[len(str(path.parent)) + 1:]
-        filename = filename.replace("versions", "constraints").replace(
-            ".cfg", ".txt"
-        )
-        constraints_path = path.parent / filename
-        constraints = ConstraintsFile(constraints_path)
-        if not constraints.path.exists():
-            constraints.path.touch()
-        for package_name, version in versions.items():
-            constraints[package_name] = version
+        filepath = versions.path
+        filename = str(filepath)[len(str(filepath.parent)) + 1 :]
+        filename = filename.replace("versions", "constraints").replace(".cfg", ".txt")
+        constraints_path = filepath.parent / filename
+        versions.to_constraints(constraints_path)
 
 
 class Manage:

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -109,6 +109,33 @@ class ConstraintsFile(BaseFile):
         if contents != new_contents:
             self.path.write_text(new_contents)
 
+    def rewrite(self):
+        """Rewrite the file based on the parsed data.
+
+        This will lose comments, and may change the order.
+        """
+        contents = []
+        if self.extends and not self.read_extends:
+            # With read_extends=True, we incorporate the versions of the
+            # extended files in our own, so we no longer need the extends.
+            for extend in self.extends:
+                contents.append(f"-c {extend}")
+
+        for package, version in self.data.items():
+            if isinstance(version, str):
+                contents.append(f"{package}=={version}")
+                continue
+            # version is a dict
+            for marker, value in version.items():
+                line = f"{package}=={value}"
+                if marker:
+                    line += f"; {marker}"
+                contents.append(line)
+
+        contents.append("")
+        new_contents = "\n".join(contents)
+        self.path.write_text(new_contents)
+
 
 class IniFile(BaseFile):
     """Ini file for mxdev.

--- a/plone/releaser/pip.py
+++ b/plone/releaser/pip.py
@@ -21,11 +21,10 @@ class ConstraintsFile(BaseFile):
         self.file_location = file_location
         self.path = pathlib.Path(self.file_location).resolve()
         self.with_markers = with_markers
-        self.markers = set()
         self.read_extends = read_extends
         self._extends = []
 
-    @property
+    @cached_property
     def extends(self):
         # Getting the data fills self._extends.
         _ignored = self.data  # noqa F841

--- a/plone/releaser/tests/input/constraints.txt
+++ b/plone/releaser/tests/input/constraints.txt
@@ -9,4 +9,5 @@ lowercase==1.0
 package==1.0
 pyspecific==1.0
 pyspecific==2.0; python_version=="3.12"
+onepython==2.1; python_version=="3.12"
 UPPERCASE==1.0

--- a/plone/releaser/tests/input/constraints2.txt
+++ b/plone/releaser/tests/input/constraints2.txt
@@ -1,0 +1,4 @@
+-c constraints3.txt
+one==1.1
+two==2.0
+three==3.2; python_version=="3.12"

--- a/plone/releaser/tests/input/constraints3.txt
+++ b/plone/releaser/tests/input/constraints3.txt
@@ -1,0 +1,4 @@
+-c constraints4.txt
+one==1.0
+three==3.0
+three==3.1; python_version=="3.12"

--- a/plone/releaser/tests/input/constraints4.txt
+++ b/plone/releaser/tests/input/constraints4.txt
@@ -1,0 +1,2 @@
+four==4.0
+five==5.0; platform_system == 'macosx'

--- a/plone/releaser/tests/input/constraints4.txt
+++ b/plone/releaser/tests/input/constraints4.txt
@@ -1,2 +1,2 @@
 four==4.0
-five==5.0; platform_system == 'macosx'
+five==5.0; platform_system == 'darwin'

--- a/plone/releaser/tests/input/versions.cfg
+++ b/plone/releaser/tests/input/versions.cfg
@@ -14,6 +14,7 @@ pyspecific = 1.0
 UPPERCASE = 1.0
 
 [versions:python312]
+onepython = 2.1
 pyspecific = 2.0
 
 [versionannotations]

--- a/plone/releaser/tests/input/versions2.cfg
+++ b/plone/releaser/tests/input/versions2.cfg
@@ -1,0 +1,9 @@
+[buildout]
+extends = versions3.cfg
+
+[versions]
+one = 1.1
+two = 2.0
+
+[versions:python312]
+three = 3.2

--- a/plone/releaser/tests/input/versions3.cfg
+++ b/plone/releaser/tests/input/versions3.cfg
@@ -1,0 +1,10 @@
+[buildout]
+extends =
+    versions4.cfg
+
+[versions]
+one = 1.0
+three = 3.0
+
+[versions:python312]
+three = 3.1

--- a/plone/releaser/tests/input/versions4.cfg
+++ b/plone/releaser/tests/input/versions4.cfg
@@ -1,0 +1,5 @@
+[versions]
+four = 4.0
+
+[versions:macosx]
+five = 5.0

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -197,6 +197,8 @@ def test_versions_file_extends():
     assert vf.extends == ["versions3.cfg"]
     vf = VersionsFile(VERSIONS_FILE3)
     assert vf.extends == ["versions4.cfg"]
+    vf = VersionsFile(VERSIONS_FILE4)
+    assert vf.extends == []
 
 
 def test_versions_file_read_extends_without_markers():

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -203,14 +203,20 @@ def test_sources_file_rewrite(tmp_path):
     # Read it fresh and compare
     sf2 = SourcesFile(copy_path)
     assert sf.raw_data == sf2.raw_data
-    # TODO re-enable this test after including the remotes:
-    # assert sf.data == sf2.data
+    assert sf.data == sf2.data
     # Some differences compared with the original:
     # - We always specify the branch.
     # - The order of the options may be different.
     assert (
         copy_path.read_text()
         == """[buildout]
+extends =
+    https://raw.githubusercontent.com/zopefoundation/Zope/master/sources.cfg
+docs-directory = ${buildout:directory}/documentation
+
+[remotes]
+plone = https://github.com/plone
+plone_push = git@github.com:plone
 
 [sources]
 docs = git ${remotes:plone}/documentation.git branch=6.0 path=${buildout:docs-directory} egg=false

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -195,6 +195,32 @@ def test_sources_file_get():
     assert base.egg
 
 
+def test_sources_file_rewrite(tmp_path):
+    copy_path = tmp_path / "sources.cfg"
+    shutil.copyfile(SOURCES_FILE, copy_path)
+    sf = SourcesFile(copy_path)
+    sf.rewrite()
+    # Read it fresh and compare
+    sf2 = SourcesFile(copy_path)
+    assert sf.raw_data == sf2.raw_data
+    # TODO re-enable this test after including the remotes:
+    # assert sf.data == sf2.data
+    # Some differences compared with the original:
+    # - We always specify the branch.
+    # - The order of the options may be different.
+    assert (
+        copy_path.read_text()
+        == """[buildout]
+
+[sources]
+docs = git ${remotes:plone}/documentation.git branch=6.0 path=${buildout:docs-directory} egg=false
+plone = git ${remotes:plone}/Plone.git pushurl=${remotes:plone_push}/Plone.git branch=6.0.x
+plone.alterego = git ${remotes:plone}/plone.alterego.git branch=master
+plone.base = git ${remotes:plone}/plone.base.git branch=main
+"""
+    )
+
+
 def test_versions_file_versions():
     vf = VersionsFile(VERSIONS_FILE)
     # All versions are reported lowercased.

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -80,6 +80,27 @@ def test_checkouts_file_remove(tmp_path):
     assert "camelcase" not in cf
 
 
+def test_checkouts_file_rewrite(tmp_path):
+    copy_path = tmp_path / "checkouts.cfg"
+    shutil.copyfile(CHECKOUTS_FILE, copy_path)
+    cf = CheckoutsFile(copy_path)
+    cf.rewrite()
+    # Read it fresh and compare
+    cf2 = CheckoutsFile(copy_path)
+    assert cf.data == cf2.data
+    # Check the entire text.  Note that packages are alphabetically sorted.
+    # Currently we get the original case, but we may change this to lowercase.
+    assert (
+        copy_path.read_text()
+        == """[buildout]
+always-checkout = force
+auto-checkout =
+    CamelCase
+    package
+"""
+    )
+
+
 def test_source_standard():
     src = Source.create_from_string(
         "git https://github.com/plone/Plone.git pushurl=git@github.com:plone/Plone.git branch=6.0.x"

--- a/plone/releaser/tests/test_pip.py
+++ b/plone/releaser/tests/test_pip.py
@@ -96,6 +96,42 @@ def test_mxdev_file_remove(tmp_path):
     assert "CamelCase" in mf
 
 
+def test_mxdev_file_rewrite(tmp_path):
+    copy_path = tmp_path / "mxdev.ini"
+    shutil.copyfile(MXDEV_FILE, copy_path)
+    mf = IniFile(copy_path)
+    mf.rewrite()
+    # Read it fresh and compare
+    mf2 = IniFile(copy_path)
+    assert mf.data == mf2.data
+    # Check the entire text.  Note that packages are alphabetically sorted.
+    # Currently we get the original case, but we may change this to lowercase.
+    assert (
+        copy_path.read_text()
+        == """[settings]
+requirements-in = requirements.txt
+requirements-out = requirements-mxdev.txt
+contraints-out = constraints-mxdev.txt
+default-use = false
+plone = https://github.com/plone
+
+[package]
+url = ${settings:plone}/package.git
+branch = main
+use = true
+
+[unused]
+url = ${settings:plone}/package.git
+branch = main
+
+[CamelCase]
+url = ${settings:plone}/CamelCase.git
+branch = main
+use = true
+"""
+    )
+
+
 def test_constraints_file_constraints():
     cf = ConstraintsFile(CONSTRAINTS_FILE)
     # All constraints are reported lowercased.

--- a/plone/releaser/tests/test_pip.py
+++ b/plone/releaser/tests/test_pip.py
@@ -227,7 +227,7 @@ def test_constraints_file_read_extends_without_markers():
 def test_constraints_file_read_extends_with_markers():
     cf = ConstraintsFile(CONSTRAINTS_FILE2, with_markers=True, read_extends=True)
     assert cf.data == {
-        "five": {"platform_system == 'macosx'": "5.0"},
+        "five": {"platform_system == 'darwin'": "5.0"},
         "four": "4.0",
         "one": "1.1",
         "three": {"": "3.0", 'python_version=="3.12"': "3.2"},

--- a/plone/releaser/tests/test_utils.py
+++ b/plone/releaser/tests/test_utils.py
@@ -9,6 +9,24 @@ INPUT_DIR = TESTS_DIR / "input"
 VERSIONS = (INPUT_DIR / "versions.cfg").read_text()
 
 
+def test_buildout_marker_to_pip_marker():
+    from plone.releaser.utils import buildout_marker_to_pip_marker as trans
+
+    assert trans("") == ""
+    assert trans("unknown") == "unknown"
+    assert trans('python_version == "3.8"') == 'python_version == "3.8"'
+    assert trans('platform_system == "Linux"') == 'platform_system == "Linux"'
+    assert trans("python2") == 'python_version < "3"'
+    assert trans("python3") == 'python_version >= "3"'
+    assert trans("python27") == 'python_version == "2.7"'
+    assert trans("python38") == 'python_version == "3.8"'
+    assert trans("python313") == 'python_version == "3.13"'
+    assert trans("pypy") == 'implementation_name == "pypy"'
+    assert trans("linux") == 'platform_system == "Linux"'
+    assert trans("macosx") == 'platform_system == "Darwin"'
+    assert trans("windows") == 'platform_system == "Windows"'
+
+
 def test_update_contents_empty():
     assert update_contents("\n", lambda x: True, "", "") == "\n"
 

--- a/plone/releaser/tests/test_versions2constraints.py
+++ b/plone/releaser/tests/test_versions2constraints.py
@@ -1,6 +1,6 @@
 from plone.releaser.manage import versions2constraints
+from plone.releaser.pip import ConstraintsFile
 
-import os
 import pathlib
 import pytest
 import shutil
@@ -14,6 +14,7 @@ VERSIONS_FILE3 = INPUT_DIR / "versions3.cfg"
 VERSIONS_FILE4 = INPUT_DIR / "versions4.cfg"
 
 
+@pytest.mark.current
 def test_versions2constraints(tmp_path):
     copy_path = tmp_path / "versions.cfg"
     constraints_file = tmp_path / "constraints.txt"
@@ -21,16 +22,19 @@ def test_versions2constraints(tmp_path):
     assert not constraints_file.exists()
     versions2constraints(path=copy_path)
     assert constraints_file.exists()
-    # TODO: we should include versions with markers:
-    # pyspecific==2.0; python_version=="3.12"
-    # onepython==2.1; python_version=="3.12"
+    cf = ConstraintsFile(constraints_file, with_markers=True)
+    print(cf.data)
     assert (
         constraints_file.read_text()
-        == """annotated==1.0
+        == """-c https://zopefoundation.github.io/Zope/releases/5.8.3/constraints.txt
+annotated==1.0
 camelcase==1.0
 duplicate==1.0
 lowercase==1.0
 package==1.0
 pyspecific==1.0
+pyspecific==2.0; python_version == "3.12"
 uppercase==1.0
-""")
+onepython==2.1; python_version == "3.12"
+"""
+    )

--- a/plone/releaser/tests/test_versions2constraints.py
+++ b/plone/releaser/tests/test_versions2constraints.py
@@ -1,0 +1,36 @@
+from plone.releaser.manage import versions2constraints
+
+import os
+import pathlib
+import pytest
+import shutil
+
+
+TESTS_DIR = pathlib.Path(__file__).parent
+INPUT_DIR = TESTS_DIR / "input"
+VERSIONS_FILE = INPUT_DIR / "versions.cfg"
+VERSIONS_FILE2 = INPUT_DIR / "versions2.cfg"
+VERSIONS_FILE3 = INPUT_DIR / "versions3.cfg"
+VERSIONS_FILE4 = INPUT_DIR / "versions4.cfg"
+
+
+def test_versions2constraints(tmp_path):
+    copy_path = tmp_path / "versions.cfg"
+    constraints_file = tmp_path / "constraints.txt"
+    shutil.copyfile(VERSIONS_FILE, copy_path)
+    assert not constraints_file.exists()
+    versions2constraints(path=copy_path)
+    assert constraints_file.exists()
+    # TODO: we should include versions with markers:
+    # pyspecific==2.0; python_version=="3.12"
+    # onepython==2.1; python_version=="3.12"
+    assert (
+        constraints_file.read_text()
+        == """annotated==1.0
+camelcase==1.0
+duplicate==1.0
+lowercase==1.0
+package==1.0
+pyspecific==1.0
+uppercase==1.0
+""")

--- a/plone/releaser/utils.py
+++ b/plone/releaser/utils.py
@@ -1,3 +1,77 @@
+def buildout_marker_to_pip_marker(marker):
+    """Translate a Buildout marker to a pip marker.
+
+    Example:
+
+        [versions:python38]
+        package = 1.0
+
+    This translates to:
+
+        package==1.0; python_version == "3.8"
+
+    The Buildout markers are defined here:
+    https://github.com/buildout/buildout/blob/3.0.1/src/zc/buildout/buildout.py#L1724
+
+    The pip markers are defined in PEP-508:
+    https://peps.python.org/pep-0508/#environment-markers
+
+    It seems hard to translate *all* possible markers.
+    But we can do the ones used in the Plone core development buildout.
+    Even with those, I do not see a 100% correct translation between the two.
+
+    Buildout supports the pip markers natively since version 3.0.0, so you can write:
+
+        [versions:python_version == "3.8"]
+        package = 1.0
+
+    See https://github.com/buildout/buildout/pull/622
+    """
+    if not marker:
+        return marker
+
+    # Python versions
+    if marker.startswith("python"):
+        if marker.startswith("python_version"):
+            # already a pip marker
+            return marker
+        if marker == "python2":
+            return 'python_version < "3"'
+        if marker == "python3":
+            return 'python_version >= "3"'
+        version = marker[len("python") :]
+        major = version[0]
+        minor = version[1:]
+        return f'python_version == "{major}.{minor}"'
+
+    # Python implementations
+    if marker in ("cpython", "pypy", "jython", "ironpython"):
+        # Buildout checks sys.version.lower().
+        # pip uses the equivalent of sys.implementation.name.
+        return f'implementation_name == "{marker}"'
+
+    # system platforms
+    # Buildout mostly uses str(sys.platform).lower() and then has a mapping to more
+    # common names.  For pip, platform_system seems best in most cases.
+    if marker == "linux":
+        return 'platform_system == "Linux"'
+    if marker == "macosx":
+        return 'platform_system == "Darwin"'
+    if marker == "windows":
+        return 'platform_system == "Windows"'
+    if marker == "solaris":
+        return 'platform_system == "SunOS"'
+    if marker == "posix":
+        return 'os_name == "posix"'
+    if marker == "cygwin":
+        return 'sys_platform == "cygwin"'
+
+    # We are missing a few, like bits64 and big_endian.
+    # Or this is an invalid marker.
+    # Or this already is a pip marker.
+    return marker
+
+
 def update_contents(
     contents, line_check, newline, filename, start_check=None, stop_check=None
 ):

--- a/plone/releaser/utils.py
+++ b/plone/releaser/utils.py
@@ -1,4 +1,6 @@
-def update_contents(contents, line_check, newline, filename, stop_check=None):
+def update_contents(
+    contents, line_check, newline, filename, start_check=None, stop_check=None
+):
     """Update contents to have a new line if needed.
 
     * contents is some file contents
@@ -6,6 +8,8 @@ def update_contents(contents, line_check, newline, filename, stop_check=None):
     * newline is the line with which we replace the matched line.
       This can be None to signal that the old line should be removed
     * filename is used for reporting.
+    * start_check is an optional function we call to check if we should start
+      trying to match.
     * stop_check is an optional function we call to check if we should stop
       trying to match.
 
@@ -17,6 +21,12 @@ def update_contents(contents, line_check, newline, filename, stop_check=None):
     while content_lines:
         line = content_lines.pop(0)
         line = line.rstrip()
+        if start_check is not None:
+            if start_check(line):
+                # We start searching now.  Disable the start_check.
+                start_check = None
+            lines.append(line)
+            continue
         if stop_check is not None and stop_check(line):
             # Put this line back.  We will handle this line and the other
             # remaining lines outside of this loop.

--- a/plone/releaser/utils.py
+++ b/plone/releaser/utils.py
@@ -54,4 +54,7 @@ def update_contents(contents, line_check, newline, filename, stop_check=None):
     if content_lines:
         lines.extend(content_lines)
 
-    return "\n".join(lines) + "\n"
+    result = "\n".join(lines)
+    if not result.endswith("\n"):
+        result += "\n"
+    return result


### PR DESCRIPTION
The command is added in the first commit (99c840723a4104ba4c1880d98b64f64ac336f208) and the almost last one (28983c6c5194a6fa258ba0feac1ce87cee356f9c).  In between I add lots of code and tests to make this almost last commit relatively small and straight forward.  What happens there, is:

* Parse the versions.cfg file into a `VersionsFile`.
* Create an empty constraints file and parse this into a `ConstraintsFile`.
* Copy the in-memory structures of the parsed `VersionsFile` (extends and version pins) with small adjustments into their counterparts in the `ConstraintsFile`.
* Then simply ask the `ConstraintsFile` to rewrite itself to disk.

The diff is very large, so maybe just try it out.  Within the coredev 6.0 buildout, use this branch and run `bin/manage versions2constraints`.  This takes `versions*.cfg` and generates `constraints*.txt` out of it.  Should work fine on customer projects as well.  Please check if things like `[versions:python38]` get translated correctly to something pip understands.

Currently, the package names are printed lowercase.  I am looking into changing this, but this involves fixing lots of tests as well.  Can do that in another PR as well.

I have been using this branch for a long time already, so normal releasing should work the same as before.  Nice thing: when you release a package, and you indeed have a constraints.txt in the buildout, then `bin/fullrelease` will update both `versions.cfg` and `constraints.txt`.
