### PR TITLE
Manage changelog: read markdown files as well.

### DIFF
--- a/news/48.bugfix
+++ b/news/48.bugfix
@@ -1,0 +1,2 @@
+Manage changelog: read markdown files as well.
+[maurits]

--- a/plone/releaser/changelog.py
+++ b/plone/releaser/changelog.py
@@ -87,6 +87,8 @@ class Changelog:
     def __init__(self, file_location=None, content=None):
         self.data = OrderedDict()
         if content is not None:
+            if isinstance(content, bytes):
+                content = content.decode("utf-8")
             self._parse(content)
         elif file_location is not None:
             with open(file_location) as f:
@@ -94,6 +96,9 @@ class Changelog:
 
     def __iter__(self):
         return self.data.__iter__()
+
+    def __eq__(self, other):
+        return self.data == other.data
 
     def iteritems(self):
         return self.data.items()

--- a/plone/releaser/tests/input/changes.md
+++ b/plone/releaser/tests/input/changes.md
@@ -1,0 +1,28 @@
+Example MarkDown changelog from Products.CMFPlone package.
+
+## 6.0.5rc1 (2023-05-25)
+
+
+### Bug fixes:
+
+- Do not truncate the sortable_title index
+  [erral] #3690
+- Fix password validation tests. [tschorr] #3784
+- Updated metadata version to 6016.
+  [maurits] #6016
+
+
+### Internal:
+
+- Update configuration files.
+  [plone devs] 2a5f5557
+
+
+## 6.0.4 (2023-04-24)
+
+
+### Bug fixes:
+
+- Prepare 6.0.4 final. No changes compared to the release candidate.
+  [maurits] #604
+

--- a/plone/releaser/tests/test_changelog.py
+++ b/plone/releaser/tests/test_changelog.py
@@ -41,3 +41,14 @@ def test_get_changes_md():
         "Internal:",
         "Update configuration files.\n[plone devs] 2a5f5557",
     ]
+
+
+def test_get_changes_content():
+    from_file = Changelog(CHANGES_RST)
+    from_string = Changelog(content=CHANGES_RST.read_bytes())
+    from_bytes = Changelog(content=CHANGES_RST.read_bytes())
+    assert "3.0.2" in from_file
+    assert "3.0.2" in from_string
+    assert "3.0.2" in from_bytes
+    assert from_file == from_string
+    assert from_string == from_bytes

--- a/plone/releaser/tests/test_changelog.py
+++ b/plone/releaser/tests/test_changelog.py
@@ -5,11 +5,12 @@ import pathlib
 
 TESTS_DIR = pathlib.Path(__file__).parent
 INPUT_DIR = TESTS_DIR / "input"
-CHANGES_FILE = INPUT_DIR / "changes.rst"
+CHANGES_RST = INPUT_DIR / "changes.rst"
+CHANGES_MD = INPUT_DIR / "changes.md"
 
 
-def test_get_changes():
-    cf = Changelog(CHANGES_FILE)
+def test_get_changes_rst():
+    cf = Changelog(CHANGES_RST)
     assert "3.0.2" in cf
     assert "3.0.3" in cf
     assert sorted(list(cf.get("3.0.3").keys())) == ["Bug fixes:", "Internal:", "other"]
@@ -23,4 +24,20 @@ def test_get_changes():
         "https://github.com/plone/plone.dexterity/issues/186 [mamico] (#187)",
         "Internal:",
         "Update configuration files.\n[plone devs] (55bda5c9)",
+    ]
+
+
+def test_get_changes_md():
+    cf = Changelog(CHANGES_MD)
+    assert "6.0.5rc1" in cf
+    assert "6.0.4" in cf
+    # assert sorted(list(cf.get("6.0.5rc1").keys())) == ["Bug fixes:", "Internal:"]
+    assert cf.get_changes("6.0.5rc1") == []
+    assert cf.get_changes("6.0.4") == [
+        "Bug fixes:",
+        "Do not truncate the sortable_title index\n[erral] #3690",
+        "Fix password validation tests. [tschorr] #3784",
+        "Updated metadata version to 6016.\n[maurits] #6016",
+        "Internal:",
+        "Update configuration files.\n[plone devs] 2a5f5557",
     ]


### PR DESCRIPTION
Fixes issue #48.

Until now I had to many parse the changelog entries of, for example `Products.CMFPlone` and `plone.app.caching`, which is irritating.

Now when I call `bin/manage changelog --start=6.0.7 --end=6.0.8 > release/changelog.txt` on coredev 6.0, there are almost no differences, except for some expected ones.
