### PR TITLE
Preserve the case of package names in versions2constraints and friends.

### DIFF
--- a/news/65.bugfix
+++ b/news/65.bugfix
@@ -1,0 +1,2 @@
+Preserve the case of package names in versions2constraints and friends.
+[maurits]

--- a/plone/releaser/base.py
+++ b/plone/releaser/base.py
@@ -12,16 +12,27 @@ class BaseFile(UserDict):
     def data(self):
         raise NotImplementedError
 
+    @property
+    def lowerkeys(self):
+        # Map from lower case key to actual key in the data.
+        return {key.lower(): key for key in self.data}
+
     def __iter__(self):
         return self.data.__iter__()
 
     def __contains__(self, package_name):
-        return package_name.lower() in self.data
+        return package_name.lower() in self.lowerkeys
 
     def __getitem__(self, package_name):
-        if package_name in self:
-            return self.data.get(package_name.lower())
-        raise KeyError
+        # self.data may be a defaultdict, so we cannot use
+        # 'return self.data[package_name]'
+        if package_name not in self:
+            raise KeyError(package_name)
+        # The package_name is in the data, but the case might differ.
+        if package_name in self.data:
+            return self.data[package_name]
+        actual_key = self.lowerkeys[package_name.lower()]
+        return self.data[actual_key]
 
     def __setitem__(self, package_name, value):
         raise NotImplementedError

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -21,10 +21,11 @@ VERSIONS_FILE4 = INPUT_DIR / "versions4.cfg"
 
 def test_checkouts_file_data():
     cf = CheckoutsFile(CHECKOUTS_FILE)
-    # The data maps lower case to actual case.
+    # The data used to map lower case to actual case,
+    # but now actual case to True.
     assert cf.data == {
-        "camelcase": "CamelCase",
-        "package": "package",
+        "CamelCase": True,
+        "package": True,
     }
 
 
@@ -40,12 +41,11 @@ def test_checkouts_file_contains():
 
 def test_checkouts_file_get():
     cf = CheckoutsFile(CHECKOUTS_FILE)
-    # The data maps lower case to actual case.
-    assert cf["package"] == "package"
-    assert cf.get("package") == "package"
-    assert cf["camelcase"] == "CamelCase"
-    assert cf["CAMELCASE"] == "CamelCase"
-    assert cf["CamelCase"] == "CamelCase"
+    assert cf["package"] is True
+    assert cf.get("package") is True
+    assert cf["camelcase"] is True
+    assert cf["CAMELCASE"] is True
+    assert cf["CamelCase"] is True
     with pytest.raises(KeyError):
         cf["nope"]
 
@@ -60,7 +60,7 @@ def test_checkouts_file_add(tmp_path):
     # Let's read it fresh, for good measure.
     cf = CheckoutsFile(copy_path)
     assert "Extra" in cf
-    assert cf.get("extra") == "Extra"
+    assert cf.get("extra") is True
 
 
 def test_checkouts_file_remove(tmp_path):
@@ -146,8 +146,7 @@ def test_source_docs():
 
 def test_sources_file_data():
     sf = SourcesFile(SOURCES_FILE)
-    # Note that the keys are lowercase.
-    assert sorted(sf.data.keys()) == ["docs", "plone", "plone.alterego", "plone.base"]
+    assert sorted(sf.data.keys()) == ["Plone", "docs", "plone.alterego", "plone.base"]
 
 
 def test_sources_file_contains():
@@ -220,7 +219,7 @@ plone_push = git@github.com:plone
 
 [sources]
 docs = git ${remotes:plone}/documentation.git branch=6.0 path=${buildout:docs-directory} egg=false
-plone = git ${remotes:plone}/Plone.git pushurl=${remotes:plone_push}/Plone.git branch=6.0.x
+Plone = git ${remotes:plone}/Plone.git pushurl=${remotes:plone_push}/Plone.git branch=6.0.x
 plone.alterego = git ${remotes:plone}/plone.alterego.git branch=master
 plone.base = git ${remotes:plone}/plone.base.git branch=main
 """
@@ -229,15 +228,14 @@ plone.base = git ${remotes:plone}/plone.base.git branch=main
 
 def test_versions_file_versions():
     vf = VersionsFile(VERSIONS_FILE)
-    # All versions are reported lowercased.
     assert vf.data == {
         "annotated": "1.0",
-        "camelcase": "1.0",
+        "CamelCase": "1.0",
         "duplicate": "1.0",
         "lowercase": "1.0",
         "package": "1.0",
         "pyspecific": "1.0",
-        "uppercase": "1.0",
+        "UPPERCASE": "1.0",
     }
 
 
@@ -275,13 +273,13 @@ def test_versions_file_versions_with_markers():
     # All versions are reported lowercased.
     assert vf.data == {
         "annotated": "1.0",
-        "camelcase": "1.0",
+        "CamelCase": "1.0",
         "duplicate": "1.0",
         "lowercase": "1.0",
         "onepython": {"python312": "2.1"},
         "package": "1.0",
         "pyspecific": {"": "1.0", "python312": "2.0"},
-        "uppercase": "1.0",
+        "UPPERCASE": "1.0",
     }
 
 
@@ -452,7 +450,6 @@ def test_versions_file_rewrite(tmp_path):
     # - the extends line is on a separate line
     # - all comments are removed
     # - the duplicate is removed
-    # - all package names are lowercased
     assert (
         copy_path.read_text()
         == """[buildout]
@@ -461,12 +458,12 @@ extends =
 
 [versions]
 annotated = 1.0
-camelcase = 1.0
+CamelCase = 1.0
 duplicate = 1.0
 lowercase = 1.0
 package = 1.0
 pyspecific = 1.0
-uppercase = 1.0
+UPPERCASE = 1.0
 """
     )
 

--- a/plone/releaser/tests/test_pip.py
+++ b/plone/releaser/tests/test_pip.py
@@ -17,10 +17,11 @@ MXDEV_FILE = INPUT_DIR / "mxdev.ini"
 
 def test_mxdev_file_data():
     mf = IniFile(MXDEV_FILE)
-    # The data maps lower case to actual case.
+    # The data used to map lower case to actual case,
+    # but now actual case to True.
     assert mf.data == {
-        "camelcase": "CamelCase",
-        "package": "package",
+        "CamelCase": True,
+        "package": True,
     }
 
 
@@ -36,12 +37,11 @@ def test_mxdev_file_contains():
 
 def test_mxdev_file_get():
     mf = IniFile(MXDEV_FILE)
-    # The data maps lower case to actual case.
-    assert mf["package"] == "package"
-    assert mf.get("package") == "package"
-    assert mf["camelcase"] == "CamelCase"
-    assert mf["CAMELCASE"] == "CamelCase"
-    assert mf["CamelCase"] == "CamelCase"
+    assert mf["package"] is True
+    assert mf.get("package") is True
+    assert mf["camelcase"] is True
+    assert mf["CAMELCASE"] is True
+    assert mf["CamelCase"] is True
     with pytest.raises(KeyError):
         mf["unused"]
     assert mf.get("unused") is None
@@ -57,7 +57,7 @@ def test_mxdev_file_add_known(tmp_path):
     # Let's read it fresh, for good measure.
     mf = IniFile(copy_path)
     assert "unused" in mf
-    assert mf["unused"] == "unused"
+    assert mf["unused"] is True
 
 
 def test_mxdev_file_add_unknown(tmp_path):
@@ -137,12 +137,12 @@ def test_constraints_file_constraints():
     # All constraints are reported lowercased.
     assert cf.data == {
         "annotated": "1.0",
-        "camelcase": "1.0",
+        "CamelCase": "1.0",
         "duplicate": "1.0",
         "lowercase": "1.0",
         "package": "1.0",
         "pyspecific": "1.0",
-        "uppercase": "1.0",
+        "UPPERCASE": "1.0",
     }
 
 
@@ -276,13 +276,13 @@ def test_constraints_file_constraints_with_markers():
     # All constraints are reported lowercased.
     assert cf.data == {
         "annotated": "1.0",
-        "camelcase": "1.0",
+        "CamelCase": "1.0",
         "duplicate": "1.0",
         "lowercase": "1.0",
         "onepython": {'python_version=="3.12"': "2.1"},
         "package": "1.0",
         "pyspecific": {"": "1.0", 'python_version=="3.12"': "2.0"},
-        "uppercase": "1.0",
+        "UPPERCASE": "1.0",
     }
 
 
@@ -300,17 +300,16 @@ def test_constraints_file_rewrite(tmp_path):
     # - the extends line is on a separate line
     # - all comments are removed
     # - the duplicate is removed
-    # - all package names are lowercased
     assert (
         copy_path.read_text()
         == """-c https://zopefoundation.github.io/Zope/releases/5.8.3/constraints.txt
 annotated==1.0
-camelcase==1.0
+CamelCase==1.0
 duplicate==1.0
 lowercase==1.0
 package==1.0
 pyspecific==1.0
-uppercase==1.0
+UPPERCASE==1.0
 """
     )
 

--- a/plone/releaser/tests/test_versions2constraints.py
+++ b/plone/releaser/tests/test_versions2constraints.py
@@ -28,13 +28,13 @@ def test_versions2constraints(tmp_path):
         constraints_file.read_text()
         == """-c https://zopefoundation.github.io/Zope/releases/5.8.3/constraints.txt
 annotated==1.0
-camelcase==1.0
+CamelCase==1.0
 duplicate==1.0
 lowercase==1.0
 package==1.0
 pyspecific==1.0
 pyspecific==2.0; python_version == "3.12"
-uppercase==1.0
+UPPERCASE==1.0
 onepython==2.1; python_version == "3.12"
 """
     )


### PR DESCRIPTION
Fixes https://github.com/plone/plone.releaser/issues/65

This gives a few changes when I run `bin/manage versions2constraints` in the 6.1 branch of `buildout.coredev`, and that is exactly what I want. :-)