### PR TITLE
When releasing, check coredev branches 6.0, 6.1, and 6.2.

### DIFF
--- a/news/62.feature
+++ b/news/62.feature
@@ -1,0 +1,3 @@
+When releasing, check coredev branches 6.0, 6.1, and 6.2.
+No longer check 5.2.
+[maurits]

--- a/plone/releaser/release.py
+++ b/plone/releaser/release.py
@@ -232,7 +232,7 @@ def update_core(data, branch=None):
 
 
 def update_other_core_branches(data):
-    CORE_BRANCHES = ["5.2", "6.0", "6.1"]
+    CORE_BRANCHES = ["6.0", "6.1", "6.2"]
     package_name = data["name"]
     root_path = os.path.join(os.getcwd(), "../../")
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     version=version,
     description="Plone release management utilities",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     # Get more strings from https://pypi.org/classifiers/
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
No longer check 5.2.