### PR TITLE
Configuring with plone.meta: use 6.2 constraints.

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -14,3 +14,4 @@ dependencies_mappings = [
 
 [tox]
 test_runner = "pytest"
+constraints_file = "https://dist.plone.org/release/6.2-dev/constraints.txt"

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ set_env =
 deps =
     pytest-plone
     pytest
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.2-dev/constraints.txt
 
 
 ##
@@ -159,7 +159,7 @@ deps =
     pytest-plone
     pytest
     coverage
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.2-dev/constraints.txt
 
 commands =
     coverage run --source plone.releaser -m pytest  {posargs} --disable-warnings {toxinidir}
@@ -176,7 +176,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.2-dev/constraints.txt
 
 commands =
     # fake version to not have to install the package
@@ -207,7 +207,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.2-dev/constraints.txt
 
 commands =
     # Generate the full dependency tree


### PR DESCRIPTION
Locally with 6.0 I got this error when running the tests:

```
  File "/Users/maurits/community/plone-coredev/6.2/src/plone.releaser/.tox/test/lib/python3.13/site-packages/pytest_plone/helpers.py", line 1, in <module>
    import gocept.pytestlayer.fixture
  File "/Users/maurits/community/plone-coredev/6.2/src/plone.releaser/.tox/test/lib/python3.13/site-packages/gocept/pytestlayer/__init__.py", line 1, in <module>
    raise RuntimeError("'gocept.pytestlayer' is deprecated."
                       " Please use 'zope.pytestlayer' instead."
                       " They are compatible besides the name.")
RuntimeError: 'gocept.pytestlayer' is deprecated. Please use 'zope.pytestlayer' instead. They are compatible besides the name.
```

Strangely, on GitHub Actions is was fine.