### PR TITLE
No longer insert buildout:docs-directory when reading sources.

### DIFF
--- a/news/+nodocsdir.bugfix
+++ b/news/+nodocsdir.bugfix
@@ -1,0 +1,3 @@
+No longer insert ``buildout:docs-directory`` when reading sources.
+The Plone core dev buildout no longer uses this.
+[maurits]

--- a/plone/releaser/buildout.py
+++ b/plone/releaser/buildout.py
@@ -376,7 +376,6 @@ class SourcesFile(BaseBuildoutFile):
 
         # Translate our data to pip.
         sources.data = self.raw_data
-        sources.settings = {"docs-directory": "documentation"}
         if "remotes" in self.config:
             remotes = self.config["remotes"]
             for key, value in remotes.items():

--- a/plone/releaser/tests/input/sources.cfg
+++ b/plone/releaser/tests/input/sources.cfg
@@ -1,16 +1,13 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/zopefoundation/Zope/master/sources.cfg
-# Define a docs directory.
-# Must be defined in this file, otherwise mr.roboto fails when it parses only sources.cfg.
-docs-directory = ${buildout:directory}/documentation
 
 [remotes]
 plone = https://github.com/plone
 plone_push = git@github.com:plone
 
 [sources]
-docs                                = git ${remotes:plone}/documentation.git egg=false branch=6.0 path=${buildout:docs-directory}
+docs                                = git ${remotes:plone}/documentation.git egg=false branch=6.0 path=extra/documentation
 Plone                               = git ${remotes:plone}/Plone.git pushurl=${remotes:plone_push}/Plone.git branch=6.0.x
 plone.alterego                      = git ${remotes:plone}/plone.alterego.git
 plone.base                          = git ${remotes:plone}/plone.base.git branch=main

--- a/plone/releaser/tests/test_buildout.py
+++ b/plone/releaser/tests/test_buildout.py
@@ -2,7 +2,6 @@ from plone.releaser.buildout import CheckoutsFile
 from plone.releaser.buildout import SourcesFile
 from plone.releaser.buildout import VersionsFile
 
-import os
 import pathlib
 import pytest
 import shutil
@@ -134,7 +133,7 @@ def test_sources_file_get():
     assert docs.url == "https://github.com/plone/documentation.git"
     assert docs.pushurl is None
     assert docs.branch == "6.0"
-    assert docs.path == f"{os.getcwd()}/documentation"
+    assert docs.path == "extra/documentation"
     assert not docs.egg
     alterego = sf["plone.alterego"]
     assert alterego.url == "https://github.com/plone/plone.alterego.git"
@@ -167,14 +166,13 @@ def test_sources_file_rewrite(tmp_path):
         == """[buildout]
 extends =
     https://raw.githubusercontent.com/zopefoundation/Zope/master/sources.cfg
-docs-directory = ${buildout:directory}/documentation
 
 [remotes]
 plone = https://github.com/plone
 plone_push = git@github.com:plone
 
 [sources]
-docs = git ${remotes:plone}/documentation.git branch=6.0 path=${buildout:docs-directory} egg=false
+docs = git ${remotes:plone}/documentation.git branch=6.0 path=extra/documentation egg=false
 Plone = git ${remotes:plone}/Plone.git pushurl=${remotes:plone_push}/Plone.git branch=6.0.x
 plone.alterego = git ${remotes:plone}/plone.alterego.git branch=master
 plone.base = git ${remotes:plone}/plone.base.git branch=main

--- a/plone/releaser/tests/test_buildout2pip.py
+++ b/plone/releaser/tests/test_buildout2pip.py
@@ -77,7 +77,6 @@ onepython==2.1; python_version == "3.12"
     assert (
         mxsources_file.read_text()
         == """[settings]
-docs-directory = documentation
 plone = https://github.com/plone
 plone_push = git@github.com:plone
 
@@ -85,7 +84,7 @@ plone_push = git@github.com:plone
 url = ${settings:plone}/documentation.git
 branch = 6.0
 install-mode = skip
-target = ${settings:docs-directory}
+target = extra/documentation
 
 [Plone]
 url = ${settings:plone}/Plone.git


### PR DESCRIPTION
The Plone core dev buildout no longer uses this.
See https://github.com/plone/buildout.coredev/pull/1021