### PR TITLE
set-package-version: add --commit option.

### DIFF
--- a/news/97.feature.rst
+++ b/news/97.feature.rst
@@ -1,0 +1,3 @@
+set-package-version: add ``--commit`` option.
+Then the changed files will be committed.
+[maurits]

--- a/src/plone/releaser/base.py
+++ b/src/plone/releaser/base.py
@@ -35,6 +35,11 @@ class BaseFile(UserDict):
         return self.data[actual_key]
 
     def __setitem__(self, package_name, value):
+        """Set item to value.
+
+        Sub classes should return True when the value was changed,
+        and False when it stayed the same.
+        """
         raise NotImplementedError
 
     def __delitem__(self, package_name):

--- a/src/plone/releaser/buildout.py
+++ b/src/plone/releaser/buildout.py
@@ -139,11 +139,13 @@ class VersionsFile(BaseBuildoutFile):
         self._data = versions
 
     def __setitem__(self, package_name, new_version):
+        changed = False
         contents = self.path.read_text()
         if not contents.endswith("\n"):
             # Make sure the file ends with a newline.
             contents += "\n"
             self.path.write_text(contents)
+            changed = True
 
         if isinstance(new_version, tuple):
             new_version, marker = new_version
@@ -151,6 +153,7 @@ class VersionsFile(BaseBuildoutFile):
             if marker not in self.markers:
                 contents = f"{contents}\n{section}\n"
                 self.path.write_text(contents)
+                changed = True
         else:
             section = "[versions]"
         newline = f"{package_name} = {new_version}"
@@ -181,6 +184,8 @@ class VersionsFile(BaseBuildoutFile):
         )
         if contents != new_contents:
             self.path.write_text(new_contents)
+            changed = True
+        return changed
 
     def rewrite(self):
         """Rewrite the file based on the parsed data.
@@ -411,11 +416,13 @@ class CheckoutsFile(BaseBuildoutFile):
         return mapping
 
     def __setitem__(self, package_name, enabled=True):
+        changed = False
         contents = self.path.read_text()
         if not contents.endswith("\n"):
             # Make sure the file ends with a newline.
             contents += "\n"
             self.path.write_text(contents)
+            changed = True
 
         def line_check(line):
             # Look for the package name on a line of its own,
@@ -429,6 +436,8 @@ class CheckoutsFile(BaseBuildoutFile):
         )
         if contents != new_contents:
             self.path.write_text(new_contents)
+            changed = True
+        return changed
 
     def set(self, package_name, new_version):
         # This method makes no sense for this class.

--- a/src/plone/releaser/manage.py
+++ b/src/plone/releaser/manage.py
@@ -11,12 +11,14 @@ from plone.releaser.buildout import Buildout
 from plone.releaser.buildout import CheckoutsFile
 from plone.releaser.buildout import SourcesFile
 from plone.releaser.buildout import VersionsFile
+from plone.releaser.package import buildout_coredev
 from plone.releaser.package import Package
 from plone.releaser.pip import ConstraintsFile
 from plone.releaser.pip import MxCheckoutsFile
 from plone.releaser.pip import MxSourcesFile
 from progress.bar import Bar
 
+import git
 import glob
 import time
 
@@ -245,7 +247,7 @@ def get_package_version(package_name, *, path=None):
         print(f"{constraints.file_location}: {package_name} {version}.")
 
 
-def set_package_version(package_name, new_version, *, path=None):
+def set_package_version(package_name, new_version, *, path=None, commit=False):
     """Pin package to new version in a versions file.
 
     This can also be a pip constraints file.
@@ -258,6 +260,7 @@ def set_package_version(package_name, new_version, *, path=None):
     If you want to add environment markers, like "python_version >= '3.0'",
     please just edit the files yourself.
     """
+    updated = []
     for constraints in _get_constraints(path=path):
         if package_name not in constraints:
             if path is None:
@@ -267,7 +270,33 @@ def set_package_version(package_name, new_version, *, path=None):
                 f"{constraints.file_location}: {package_name} not pinned yet. "
                 f"Adding pin because you explicitly gave the path."
             )
-        constraints.set(package_name, new_version)
+        # Call the 'set' function.  This will return True if the file has changed.
+        if constraints.set(package_name, new_version):
+            updated.append(constraints)
+    if not commit:
+        return
+    if not updated:
+        print("Nothing to commit.")
+        return
+    # There are updates and we want to commit them.
+    with buildout_coredev() as core_repo:
+        added = []
+        for constraints in updated:
+            try:
+                core_repo.git.add(constraints.path)
+                added.append(constraints.path)
+            except git.GitCommandError:
+                # most likely a file that is ignored by git
+                pass
+        if not added:
+            print("WARNING: no files were added to the commit")
+            return
+        print("Committing changes to these files:")
+        for path in added:
+            print(f"- {path}")
+        message = f"{package_name} {new_version}"
+        core_repo.git.commit(message=message)
+        print(f"Committed changes: {message}")
 
 
 def _get_paths(path, patterns):

--- a/src/plone/releaser/package.py
+++ b/src/plone/releaser/package.py
@@ -41,8 +41,8 @@ def git_repo(source):
 def buildout_coredev():
     """Context manager for buildout.coredev git repositories.
 
-    It ensures that the git repository is cloned on a temporal folder and that
-    everything is cleaned up after being used.
+    Or actually any git repository in the current working directory.
+    But plone.releaser is targeted at the Plone core development buildout.
     """
     repo = git.Repo(os.getcwd())
     yield repo

--- a/src/plone/releaser/pip.py
+++ b/src/plone/releaser/pip.py
@@ -89,10 +89,12 @@ class ConstraintsFile(BaseFile):
         return constraints
 
     def __setitem__(self, package_name, new_version):
+        changed = False
         contents = self.path.read_text()
         if not contents.endswith("\n"):
             contents += "\n"
             self.path.write_text(contents)
+            changed = True
 
         newline = f"{package_name}=={new_version}"
         # Look for 'package name==version' on a line of its own,
@@ -108,6 +110,8 @@ class ConstraintsFile(BaseFile):
         )
         if contents != new_contents:
             self.path.write_text(new_contents)
+            changed = True
+        return changed
 
     def rewrite(self):
         """Rewrite the file based on the parsed data.
@@ -382,18 +386,20 @@ class MxCheckoutsFile(BaseFile):
             if not enabled:
                 # The wanted state is the default state, so do nothing.
                 print(f"{self.file_location}: {package_name} not in checkouts.")
-                return
+                return False
             self.append_package(package_name, enabled=enabled)
-            return
+            return True
         package_name = stored_package_name
         use = package_name in self
         if use and enabled:
             print(f"{self.file_location}: {package_name} already in checkouts.")
-            return
+            return False
         if not use and not enabled:
             print(f"{self.file_location}: {package_name} not in checkouts.")
-            return
+            return False
 
+        # So the package is already configured in the checkouts file, but the
+        # value must be updated.
         contents = self.path.read_text()
         if not contents.endswith("\n"):
             contents += "\n"
@@ -437,6 +443,7 @@ class MxCheckoutsFile(BaseFile):
 
         contents = "\n".join(lines)
         self.path.write_text(contents)
+        return True
 
     def rewrite(self):
         """Rewrite the file based on the parsed data.


### PR DESCRIPTION
Then the changed files will be committed.
The commit message will be `{package} {version}`.
Fixes https://github.com/plone/plone.releaser/issues/97

Sample run:

```
$ bin/manage set-package-version plone.app.locales 1.2.3 --commit
constraints.txt: have set 'plone.app.locales==1.2.3'.
constraints-all.txt: plone.app.locales missing.
constraints-ecosystem.txt: plone.app.locales missing.
constraints-extra.txt: plone.app.locales missing.
constraints-mxdev.txt: have set 'plone.app.locales==1.2.3'.
versions.cfg: have set 'plone.app.locales = 1.2.3'.
versions-ecosystem.cfg: plone.app.locales missing.
versions-all.cfg: plone.app.locales missing.
versions-mxdev.cfg: have set 'plone.app.locales = 1.2.3'.
versions-extra.cfg: plone.app.locales missing.
Committing changes to these files:
- /Users/maurits/community/plone-coredev/6.2/constraints.txt
- /Users/maurits/community/plone-coredev/6.2/versions.cfg
Committed changes: plone.app.locales 1.2.3
```
