### PR TITLE
versions2constraints: fail when this would lead to conflicts in pip.

### DIFF
--- a/news/89.bugfix.rst
+++ b/news/89.bugfix.rst
@@ -1,0 +1,1 @@
+``versions2constraints``: fail when this would lead to conflicts in pip.  [maurits]

--- a/src/plone/releaser/buildout.py
+++ b/src/plone/releaser/buildout.py
@@ -12,6 +12,7 @@ from textwrap import indent
 import os
 import pathlib
 import re
+import sys
 
 
 class BaseBuildoutFile(BaseFile):
@@ -261,6 +262,25 @@ class VersionsFile(BaseBuildoutFile):
         An option would be to always do this for Buildout as well.
         Or have a command to normalize a buildout file, with this and other
         small changes.
+
+        We need to check one corner case to prevent problems.
+        Take this buildout file:
+
+            [versions]
+            tomli = 2.3.0
+
+            [versions:python310]
+            tomli = 2.2.1
+
+        This overrides the version just fine for Buildout.
+        But translated to pip constraints it would be this:
+
+            tomli==2.3.0
+            tomli==2.2.1; python_version == "3.10"
+
+        On Python 3.10 this would mean a version conflict.
+        See https://github.com/plone/plone.releaser/issues/89
+        So we should fail when we see this.
         """
         new_data = {}
         for package, version in self.data.items():
@@ -271,8 +291,32 @@ class VersionsFile(BaseBuildoutFile):
             new_version = {}
             for marker, value in version.items():
                 if not marker:
-                    new_version[marker] = value
-                    continue
+                    print(
+                        "Can't translate buildout version pins to pip constraints "
+                        f"for package '{package}'."
+                    )
+                    print(
+                        f"Please move the {value} pin from [versions] to "
+                        "[versions:some other marker]"
+                    )
+                    print("")
+                    for marker, value in version.items():
+                        if marker:
+                            print(f"  [versions:{marker}]")
+                        else:
+                            print("  [versions]")
+                        print(f"  {package} = {value}")
+                        print("")
+                    if len(version) == 2:
+                        marker_text = "the marker"
+                    else:
+                        marker_text = "one of the markers"
+                    print(
+                        f"Otherwise, if {marker_text} is valid, this results in "
+                        "conflicting dependencies when installing with pip."
+                    )
+                    sys.exit(1)
+
                 # If this is a Buildout-specific marker, we need to translate it.
                 new_marker = buildout_marker_to_pip_marker(marker)
                 new_version[new_marker] = value

--- a/src/plone/releaser/tests/input/badversions.cfg
+++ b/src/plone/releaser/tests/input/badversions.cfg
@@ -1,0 +1,12 @@
+[versions]
+tomli = 2.3.0
+
+[versions:python310]
+tomli = 2.2.1
+
+# This overrides the version just fine for Buildout.
+# But translated to pip constraints it would be this:
+# tomli==2.3.0
+# tomli==2.2.1; python_version == "3.10"
+# On Python 3.10 this would mean a version conflict.
+# See https://github.com/plone/plone.releaser/issues/89

--- a/src/plone/releaser/tests/input/goodversions.cfg
+++ b/src/plone/releaser/tests/input/goodversions.cfg
@@ -1,0 +1,24 @@
+[buildout]
+# We should not touch this.
+extends = https://zopefoundation.github.io/Zope/releases/5.8.3/versions.cfg
+
+[versions]
+# comment = 1.0
+annotated = 1.0
+CamelCase = 1.0
+duplicate = 1.0
+duplicate = 1.0
+lowercase = 1.0
+package = 1.0
+UPPERCASE = 1.0
+
+[versions:python_version<"3.12"]
+pyspecific = 1.0
+
+[versions:python312]
+onepython = 2.1
+pyspecific = 2.0
+
+[versionannotations]
+annotated =
+    annotated = 1.1 conflicts with package = 1.1

--- a/src/plone/releaser/tests/input/versions3.cfg
+++ b/src/plone/releaser/tests/input/versions3.cfg
@@ -4,6 +4,8 @@ extends =
 
 [versions]
 one = 1.0
+
+[versions:python_version<"3.12"]
 three = 3.0
 
 [versions:python312]

--- a/src/plone/releaser/tests/test_buildout.py
+++ b/src/plone/releaser/tests/test_buildout.py
@@ -201,7 +201,7 @@ def test_versions_file_extends():
 
 def test_versions_file_read_extends_without_markers():
     vf = VersionsFile(VERSIONS_FILE2, read_extends=True)
-    assert vf.data == {"four": "4.0", "one": "1.1", "three": "3.0", "two": "2.0"}
+    assert vf.data == {"four": "4.0", "one": "1.1", "two": "2.0"}
 
 
 def test_versions_file_read_extends_with_markers():
@@ -210,7 +210,7 @@ def test_versions_file_read_extends_with_markers():
         "five": {"macosx": "5.0"},
         "four": "4.0",
         "one": "1.1",
-        "three": {"": "3.0", "python312": "3.2"},
+        "three": {'python_version<"3.12"': "3.0", "python312": "3.2"},
         "two": "2.0",
     }
 
@@ -469,7 +469,6 @@ def test_versions_file_rewrite_read_extends_without_markers(tmp_path):
     assert copy_path.read_text() == """[versions]
 four = 4.0
 one = 1.1
-three = 3.0
 two = 2.0
 """
 
@@ -491,11 +490,13 @@ def test_versions_file_rewrite_read_extends_with_markers(tmp_path):
     assert copy_path.read_text() == """[versions]
 four = 4.0
 one = 1.1
-three = 3.0
 two = 2.0
 
 [versions:macosx]
 five = 5.0
+
+[versions:python_version<"3.12"]
+three = 3.0
 
 [versions:python312]
 three = 3.2

--- a/src/plone/releaser/tests/test_buildout2pip.py
+++ b/src/plone/releaser/tests/test_buildout2pip.py
@@ -6,7 +6,7 @@ import shutil
 
 TESTS_DIR = pathlib.Path(__file__).parent
 INPUT_DIR = TESTS_DIR / "input"
-VERSIONS_FILE = INPUT_DIR / "versions.cfg"
+VERSIONS_FILE = INPUT_DIR / "goodversions.cfg"
 SOURCES_FILE = INPUT_DIR / "sources.cfg"
 CHECKOUTS_FILE = INPUT_DIR / "checkouts.cfg"
 
@@ -27,7 +27,10 @@ def test_buildout2pip_one_path(tmp_path):
         "lowercase": "1.0",
         "onepython": {'python_version == "3.12"': "2.1"},
         "package": "1.0",
-        "pyspecific": {"": "1.0", 'python_version == "3.12"': "2.0"},
+        "pyspecific": {
+            'python_version<"3.12"': "1.0",
+            'python_version == "3.12"': "2.0",
+        },
     }
     assert (
         constraints_file.read_text()
@@ -37,9 +40,9 @@ CamelCase==1.0
 duplicate==1.0
 lowercase==1.0
 package==1.0
-pyspecific==1.0
-pyspecific==2.0; python_version == "3.12"
 UPPERCASE==1.0
+pyspecific==1.0; python_version<"3.12"
+pyspecific==2.0; python_version == "3.12"
 onepython==2.1; python_version == "3.12"
 """
     )
@@ -67,9 +70,9 @@ CamelCase==1.0
 duplicate==1.0
 lowercase==1.0
 package==1.0
-pyspecific==1.0
-pyspecific==2.0; python_version == "3.12"
 UPPERCASE==1.0
+pyspecific==1.0; python_version<"3.12"
+pyspecific==2.0; python_version == "3.12"
 onepython==2.1; python_version == "3.12"
 """
     )

--- a/src/plone/releaser/tests/test_versions2constraints.py
+++ b/src/plone/releaser/tests/test_versions2constraints.py
@@ -2,6 +2,7 @@ from plone.releaser.manage import versions2constraints
 from plone.releaser.pip import ConstraintsFile
 
 import pathlib
+import pytest
 import shutil
 
 TESTS_DIR = pathlib.Path(__file__).parent
@@ -10,6 +11,7 @@ VERSIONS_FILE = INPUT_DIR / "versions.cfg"
 VERSIONS_FILE2 = INPUT_DIR / "versions2.cfg"
 VERSIONS_FILE3 = INPUT_DIR / "versions3.cfg"
 VERSIONS_FILE4 = INPUT_DIR / "versions4.cfg"
+BAD_VERSIONS_FILE = INPUT_DIR / "badversions.cfg"
 
 
 def test_versions2constraints_one_path(tmp_path):
@@ -119,3 +121,14 @@ three==3.1; python_version == "3.12"
     assert constraints4_file.read_text() == """four==4.0
 five==5.0; platform_system == "Darwin"
 """
+
+
+def test_versions2constraints_bad_versions(tmp_path, capsys):
+    # Not all valid buildout versions can be translated into valid pip constraints.
+    # We should fail.
+    copy_path = tmp_path / "versions.cfg"
+    shutil.copyfile(BAD_VERSIONS_FILE, copy_path)
+    with pytest.raises(SystemExit):
+        versions2constraints(path=copy_path)
+    captured = capsys.readouterr()
+    assert "Can't translate buildout version pins to pip constraints" in captured.out

--- a/src/plone/releaser/tests/test_versions2constraints.py
+++ b/src/plone/releaser/tests/test_versions2constraints.py
@@ -7,17 +7,19 @@ import shutil
 
 TESTS_DIR = pathlib.Path(__file__).parent
 INPUT_DIR = TESTS_DIR / "input"
-VERSIONS_FILE = INPUT_DIR / "versions.cfg"
 VERSIONS_FILE2 = INPUT_DIR / "versions2.cfg"
 VERSIONS_FILE3 = INPUT_DIR / "versions3.cfg"
 VERSIONS_FILE4 = INPUT_DIR / "versions4.cfg"
+# The versions.cfg file is bad when you want to translate it to pip constraints.
+# So have one explicitly bad file for testing, and one good file.
 BAD_VERSIONS_FILE = INPUT_DIR / "badversions.cfg"
+GOOD_VERSIONS_FILE = INPUT_DIR / "goodversions.cfg"
 
 
 def test_versions2constraints_one_path(tmp_path):
     copy_path = tmp_path / "versions.cfg"
     constraints_file = tmp_path / "constraints.txt"
-    shutil.copyfile(VERSIONS_FILE, copy_path)
+    shutil.copyfile(GOOD_VERSIONS_FILE, copy_path)
     assert not constraints_file.exists()
     versions2constraints(path=copy_path)
     assert constraints_file.exists()
@@ -30,7 +32,10 @@ def test_versions2constraints_one_path(tmp_path):
         "lowercase": "1.0",
         "onepython": {'python_version == "3.12"': "2.1"},
         "package": "1.0",
-        "pyspecific": {"": "1.0", 'python_version == "3.12"': "2.0"},
+        "pyspecific": {
+            'python_version<"3.12"': "1.0",
+            'python_version == "3.12"': "2.0",
+        },
     }
     assert (
         constraints_file.read_text()
@@ -40,9 +45,9 @@ CamelCase==1.0
 duplicate==1.0
 lowercase==1.0
 package==1.0
-pyspecific==1.0
-pyspecific==2.0; python_version == "3.12"
 UPPERCASE==1.0
+pyspecific==1.0; python_version<"3.12"
+pyspecific==2.0; python_version == "3.12"
 onepython==2.1; python_version == "3.12"
 """
     )
@@ -57,7 +62,7 @@ def test_versions2constraints_all(tmp_path):
     constraints2_file = tmp_path / "constraints2.txt"
     constraints3_file = tmp_path / "constraints3.txt"
     constraints4_file = tmp_path / "constraints4.txt"
-    shutil.copyfile(VERSIONS_FILE, versions_path)
+    shutil.copyfile(GOOD_VERSIONS_FILE, versions_path)
     shutil.copyfile(VERSIONS_FILE2, versions2_path)
     shutil.copyfile(VERSIONS_FILE3, versions3_path)
     shutil.copyfile(VERSIONS_FILE4, versions4_path)
@@ -79,7 +84,10 @@ def test_versions2constraints_all(tmp_path):
         "lowercase": "1.0",
         "onepython": {'python_version == "3.12"': "2.1"},
         "package": "1.0",
-        "pyspecific": {"": "1.0", 'python_version == "3.12"': "2.0"},
+        "pyspecific": {
+            'python_version<"3.12"': "1.0",
+            'python_version == "3.12"': "2.0",
+        },
     }
     assert (
         constraints_file.read_text()
@@ -89,9 +97,9 @@ CamelCase==1.0
 duplicate==1.0
 lowercase==1.0
 package==1.0
-pyspecific==1.0
-pyspecific==2.0; python_version == "3.12"
 UPPERCASE==1.0
+pyspecific==1.0; python_version<"3.12"
+pyspecific==2.0; python_version == "3.12"
 onepython==2.1; python_version == "3.12"
 """
     )
@@ -109,11 +117,11 @@ three==3.2; python_version == "3.12"
     cf3 = ConstraintsFile(constraints3_file, with_markers=True)
     assert cf3.data == {
         "one": "1.0",
-        "three": {"": "3.0", 'python_version == "3.12"': "3.1"},
+        "three": {'python_version<"3.12"': "3.0", 'python_version == "3.12"': "3.1"},
     }
     assert constraints3_file.read_text() == """-c constraints4.txt
 one==1.0
-three==3.0
+three==3.0; python_version<"3.12"
 three==3.1; python_version == "3.12"
 """
     cf4 = ConstraintsFile(constraints4_file, with_markers=True)


### PR DESCRIPTION
Fixes https://github.com/plone/plone.releaser/issues/89

This actually leads to test failures.
The output nicely shows the problem:

```
Can't translate buildout version pins to pip constraints for package 'pyspecific'.
Please move the 1.0 pin from [versions] to [versions:some other marker]

  [versions]
  pyspecific = 1.0

  [versions:python312]
  pyspecific = 2.0

Otherwise, if the marker is valid, this results in conflicting dependencies when installing with pip.
```

So in the second commit I fix the test failures.